### PR TITLE
move dc connection event outside of open

### DIFF
--- a/examples/p2p-textchat/script.js
+++ b/examples/p2p-textchat/script.js
@@ -21,7 +21,10 @@ $(function() {
     $('#pid').text(id);
   });
   // Await connections from others
-  peer.on('connection', connect);
+  peer.on('connection', c => {
+    // Show connection when it is completely ready
+    c.on('open', () => connect(c));
+  });
   peer.on('error', err => console.log(err));
 
   // Prepare file drop box.

--- a/src/peer.js
+++ b/src/peer.js
@@ -555,11 +555,8 @@ class Peer extends EventEmitter {
 
         logger.log('DataConnection created in OFFER');
 
-        // _addConnection() needs to be outside of the open event or else open won't fire.
         this._addConnection(offerMessage.src, connection);
-        connection.on(DataConnection.EVENTS.open.key, () => {
-          this.emit(Peer.EVENTS.connection.key, connection);
-        });
+        this.emit(Peer.EVENTS.connection.key, connection);
       } else {
         logger.warn('Received malformed connection type: ', offerMessage.connectionType);
       }


### PR DESCRIPTION
this way we can always catch dc.on('open') events