### PR TITLE
Fix example to use play()

### DIFF
--- a/examples/p2p-videochat/script.js
+++ b/examples/p2p-videochat/script.js
@@ -126,7 +126,9 @@ $(function() {
     }
     // Wait for stream on the call, then set peer video display
     call.on('stream', stream => {
-      $('#their-video').get(0).srcObject = stream;
+      const el = $('#their-video').get(0);
+      el.srcObject = stream;
+      el.play();
     });
 
     // UI stuff


### PR DESCRIPTION
All the other media examples use play(), so let's make the p2p-videochat example be consistent with the others.

This PR only touches the example, so the target branch is master.