### PR TITLE
fix receiveAudio/VideoEnabled

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -306,10 +306,11 @@ class Negotiator extends EventEmitter {
         this._recvonlyState.video && this._pc.addTransceiver('video').setDirection('recvonly');
         createOfferPromise = this._pc.createOffer();
       } else {
-        createOfferPromise = this._pc.createOffer({
-          offerToReceiveAudio: this._recvonlyState.audio,
-          offerToReceiveVideo: this._recvonlyState.video,
-        });
+        const offerOptions = {};
+        // the offerToReceiveXXX options are defined in the specs as boolean but `undefined` acts differently from false
+        this._recvonlyState.audio && (offerOptions.offerToReceiveAudio = true);
+        this._recvonlyState.video && (offerOptions.offerToReceiveVideo = true);
+        createOfferPromise = this._pc.createOffer(offerOptions);
       }
     }
 


### PR DESCRIPTION
Having an audio track and setting receiveVideoEnabled would set the audio to sendonly.

This PR fixes it so that it will be set to sendrecv.

---
Environment
occurs on both FF 57.0 and Chrome 62.0.3202.94

Steps to reproduce
```A has Video Only stream
B has Audio and Video stream

A calls B with audioRecvEnabled=true
B answers with Audio and Video
```


What should happen
```A shows B's Audio and Video
B shows A's Video (no audio)
```


What happens
```A shows B's Audio (no video)
B shows A's Video (no audio)
```