### PR TITLE
Close child-nodes of a room when user ends the room

### DIFF
--- a/examples/fullmesh-videochat/script.js
+++ b/examples/fullmesh-videochat/script.js
@@ -111,6 +111,7 @@ $(function() {
   }
 
   function step2() {
+    $('#their-videos').empty();
     $('#step1, #step3').hide();
     $('#step2').show();
     $('#join-room').focus();


### PR DESCRIPTION
Peer video views in an active room remain even if user ends the call to the room.
How about closing all video nodes in step2()?