### PR TITLE
Promisify listAllPeers()

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -257,7 +257,7 @@ class Peer extends EventEmitter {
 
   /**
    * Call Rest API and get the list of peerIds assciated with API key.
-   * @param {function} cb - The callback function that is called after XHR.
+   * @param {function} [cb] - The callback function that is called after XHR.
    */
   listAllPeers(cb) {
     // for Promise API
@@ -271,7 +271,7 @@ class Peer extends EventEmitter {
       .catch(err => {
         switch (err.message) {
           case 'OPEN_ERROR': {
-            // do nothing(backward compatible)
+            // do nothing(for backward compatible)
             break;
           }
           case 'HTTP_ERROR': {
@@ -329,12 +329,12 @@ class Peer extends EventEmitter {
         }
 
         switch (http.status) {
-          case 401: {
-            reject(new Error('PERMISSION_ERROR'));
-            break;
-          }
           case 200: {
             resolve(JSON.parse(http.responseText));
+            break;
+          }
+          case 401: {
+            reject(new Error('PERMISSION_ERROR'));
             break;
           }
           default: {

--- a/src/peer.js
+++ b/src/peer.js
@@ -262,11 +262,9 @@ class Peer extends EventEmitter {
   listAllPeers(cb) {
     // for Promise API
     if (typeof cb !== 'function') {
-      console.log('promise api');
       return this._listAllPeersPromise();
     }
 
-    console.log('callback api');
     // for Callback API
     this._listAllPeersPromise()
       .then(cb)
@@ -307,12 +305,10 @@ class Peer extends EventEmitter {
    * @return {Promise} Promise resolved with results of API call.
    */
   _listAllPeersPromise() {
-    console.log('open check');
     if (!this._checkOpenStatus()) {
       return Promise.reject(new Error('OPEN_ERROR'));
     }
 
-    console.log('return promise');
     return new Promise((resolve, reject) => {
       const http = new XMLHttpRequest();
       const url = `${this.socket.signalingServerUrl}/api/apikeys/${


### PR DESCRIPTION
Before

```js
// error handlings are included
peer.listAllPeers(ids => {});
```

After
```js
// same as before
peer.listAllPeers(ids => {});

// or you can go with Promise 
peer.listAllPeers()
  .then(ids => {})
  // but you have to handle errors manually
  .catch(err => {
    switch (err.message) {
      case 'OPEN_ERROR': {
      }
      case 'HTTP_ERROR': {
      }
      case 'SERVER_ERROR': {
      }
      case 'PERMISSION_ERROR': {
      }
    }
  });
```