### PR TITLE
expose rtcPeerConnection 

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -72,6 +72,15 @@ class Connection extends EventEmitter {
   }
 
   /**
+   * Gets the RTCPeerConnection object used by this connection. Modifying the
+   * RTCPeerConnection can cause unexpected errors. Suggested for advanced users only.
+   * @return {RTCPeerConnection} - The RTCPeerConnection used by this connection.
+   */
+  getRTCPeerConnection() {
+    return this._negotiator._pc;
+  }
+
+  /**
    * Handle an sdp answer message from the remote peer.
    * @param {object} answerMessage - Message object containing sdp answer.
    */

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -58,6 +58,22 @@ class MeshRoom extends Room {
   }
 
   /**
+   * Gets the RTCPeerConnection objects used by Connections in this room. Modifying the
+   * RTCPeerConnection can cause unexpected errors. Suggested for advanced users only.
+   * @return {Object} - An object containing the media RTCPeerConnections used by this room with the peerId as the key.
+   */
+  getRTCPeerConnections() {
+    // TODO: add a `type` argument specifying connection type after we implement data connections in meshRoom.
+    const peerConnections = {};
+    for (const [peerId, connections] of Object.entries(this.connections)) {
+      if (Array.isArray(connections) && connections.length > 0) {
+        peerConnections[peerId] = connections[0].getRTCPeerConnection();
+      }
+    }
+    return peerConnections;
+  }
+
+  /**
    * Called by client app to create DataConnections.
    * It emit getPeers event for getting peerIds of all of room participant.
    * After getting peerIds, makeDCs is called.

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -66,7 +66,7 @@ class MeshRoom extends Room {
     // TODO: add a `type` argument specifying connection type after we implement data connections in meshRoom.
     const peerConnections = {};
     for (const [peerId, connections] of Object.entries(this.connections)) {
-      if (Array.isArray(connections) && connections.length > 0) {
+      if (connections.length > 0) {
         peerConnections[peerId] = connections[0].getRTCPeerConnection();
       }
     }

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -62,6 +62,15 @@ class SFURoom extends Room {
   }
 
   /**
+   * Gets the RTCPeerConnection object used by this room. Modifying the
+   * RTCPeerConnection can cause unexpected errors. Suggested for advanced users only.
+   * @return {RTCPeerConnection} - The RTCPeerConnection used by this room.
+   */
+  getRTCPeerConnection() {
+    return this._negotiator._pc;
+  }
+
+  /**
    * Handles Offer message from SFU server.
    * It create new RTCPeerConnection object.
    * @param {object} offerMessage - Message object containing Offer SDP.

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -38,6 +38,7 @@ describe('DataConnection', () => {
       cleanup: cleanupSpy,
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
+      _pc: {},
     });
     // hoist statics
     negotiatorStub.EVENTS = Negotiator.EVENTS;
@@ -701,6 +702,16 @@ describe('DataConnection', () => {
       assert.equal(dc.open, false);
 
       assert(cleanupSpy.called);
+    });
+  });
+
+  describe('getRTCPeerConnection', () => {
+    it('should get the RTCPeerConnection from the negotiator', () => {
+      const dc = new DataConnection('remoteId', {});
+
+      const pc = dc.getRTCPeerConnection();
+      assert(pc);
+      assert.equal(pc, dc._negotiator._pc);
     });
   });
 });

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -38,6 +38,7 @@ describe('MediaConnection', () => {
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
       replaceStream: replaceSpy,
+      _pc: {},
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;
@@ -382,6 +383,16 @@ describe('MediaConnection', () => {
       assert.equal(mc.open, false);
 
       assert(cleanupSpy.called);
+    });
+  });
+
+  describe('getRTCPeerConnection', () => {
+    it('should get the RTCPeerConnection from the negotiator', () => {
+      const mc = new MediaConnection('remoteId', { stream: {} });
+
+      const pc = mc.getRTCPeerConnection();
+      assert(pc);
+      assert.equal(pc, mc._negotiator._pc);
     });
   });
 });

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -582,4 +582,22 @@ describe('SFURoom', () => {
       sfuRoom.getLog();
     });
   });
+
+  describe('getRTCPeerConnection', () => {
+    beforeEach(() => {
+      // We create a new sfuRoom here instead of using the default one since we don't want the stream.
+      sfuRoom = new SFURoom(sfuRoomName, peerId, {
+        pcConfig: pcConfig,
+      });
+    });
+
+    it('should get the media RTCPeerConnection from the negotiator', () => {
+      // need to call handleOffer to set up the Negotiator.
+      sfuRoom.handleOffer({ offer: { sdp: '', type: 'offer' } });
+
+      const pc = sfuRoom.getRTCPeerConnection();
+      assert(pc);
+      assert.equal(pc, sfuRoom._negotiator._pc);
+    });
+  });
 });


### PR DESCRIPTION
allows users to use `getStats()` etc

We ended up just returning media rtcPeerConnections for the rooms because we haven't implemented data yet.
We will add a `type` argument to `getRTCPeerConnections()` when we need data.