### PR TITLE
WIP: call replaceTrack when implemented by browser

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -594,8 +594,6 @@ class Negotiator extends EventEmitter {
    * @private
    */
   _replacePerStream(newStream) {
-    const localStreams = this._pc.getLocalStreams();
-
     // Temporarily unset onnegotiationneeded so that it doesn't do anything.
     // Leaving this set will cause an extra negotiation on removeStream that will cause the
     // signalingState on the answer side to enter an unexpected state, leading to errors.
@@ -603,8 +601,12 @@ class Negotiator extends EventEmitter {
     this._pc.onnegotiationneeded = () => {};
 
     // We assume that there is at most 1 stream in localStreams
-    if (localStreams.length > 0) {
-      this._pc.removeStream(localStreams[0]);
+    const localSenders = this._pc.getSenders();
+    if (localSenders.length > 0) {
+      localSenders.forEach(rtpSender => {
+        // Chrome M64(Stable) has already implemented removeTrack. (replaceTrack will come at M65)
+        this._pc.removeTrack(rtpSender);
+      });
     }
 
     this._replaceStreamCalled = true;

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -106,7 +106,7 @@ class Negotiator extends EventEmitter {
     // This doesn't require renegotiation.
     // Firefox 53 has both getSenders and getLocalStreams,
     // but Google Chrome 61 has only getLocalStreams.
-    if (this._isRtpSenderAvailable) {
+    if (this._isReplaceTrackAvailable) {
       this._replacePerTrack(newStream);
     } else {
       this._replacePerStream(newStream);
@@ -195,6 +195,8 @@ class Negotiator extends EventEmitter {
     this._isOnTrackAvailable = 'ontrack' in RTCPeerConnection.prototype;
     this._isRtpSenderAvailable =
       typeof RTCPeerConnection.prototype.getSenders === 'function';
+    this._isReplaceTrackAvailable =
+      typeof RTCRtpSender.prototype.replaceTrack === 'function';
     this._isRtpLocalStreamsAvailable =
       typeof RTCPeerConnection.prototype.getLocalStreams === 'function';
     this._isAddTransceiverAvailable =


### PR DESCRIPTION
Do not merge this PR until all problems are cleared. hopefully fix #36.

## Problem

As https://support.skyway.io/hc/ja/community/posts/360000315127-replaceStream%E3%81%8C%E5%8B%95%E4%BD%9C%E3%81%97%E3%81%BE%E3%81%9B%E3%82%93?page=1#community_comment_360000099888 says, `replaceStream` doesn't work as we expected because Chrome M64 has implemented `RtpSender` but hasn't `replaceTrack`, which causes ` TypeError: sender.replaceTrack is not a function` error message.

## This PR (WIP)

This PR checks whether `replaceTrack` is implemented or not, and calls replaceStream if `replaceTrack` isn't implemented.

## Status

- P2P example works as I expected(= replaceStream works)
- SFU example doesn't work as I expected
  - `replaceStream` changes the local mediaStream. However at the opponent side, the video seems same as the previous stream. Could you reproduce this, @leader22 ?
  - I haven't found the root cause of this. 
- ESLint fails because of RtpSender.