### PR TITLE
Force use stream methods in chrome instead of track methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyway-js",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -311,7 +311,7 @@ describe('Negotiator', () => {
         negotiator._pc.removeTrack = removeTrackStub;
         negotiator._pc.onnegotiationneeded = negotiationNeededStub;
         negotiator._isRtpSenderAvailable = true;
-        negotiator._isReplaceTrackAvailable = true;
+        negotiator._isForceUseStreamMethods = false;
 
         audioSender = {
           track: {


### PR DESCRIPTION
Chrome will be implemented replaceTrack in M65.
But Chrome can't connect properly to Firefox using addTrack/replaceTrack.

When Chrome supports UnifiedPlan, we will fix sdk to use the track methods in Chrome. 
Until then we will use the stream methods in Chrome.