### PR TITLE
Fix removal of remote video element

### DIFF
--- a/examples/sfu-videochat/script.js
+++ b/examples/sfu-videochat/script.js
@@ -112,6 +112,7 @@ $(function() {
   }
 
   function step2() {
+    $('#their-videos').empty();
     $('#step1, #step3').hide();
     $('#step2').show();
     $('#join-room').focus();


### PR DESCRIPTION
The remote element remains after a client left. This PR removes the remote video element after the client left.