### PR TITLE
Bug/fix chrome64 ff59 replacestream incompatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2845,6 +2845,11 @@
         "minimalistic-assert": "1.0.0"
       }
     },
+    "detect-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-2.1.0.tgz",
+      "integrity": "sha512-yZSZYvGiMS7lRnufWQX3hT3SfnFTzEAYDFB3CTagyKimoxya11HHaTcaRiaJY0wK5M922PMTT1V/nRRW2cDgWg=="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "webpack": "^3.3.0"
   },
   "dependencies": {
+    "detect-browser": "^2.1.0",
     "enum": "git+https://github.com/eastandwest/enum.git#react-native",
     "events": "^1.1.0",
     "js-binarypack": "0.0.9",

--- a/src/peer.js
+++ b/src/peer.js
@@ -10,6 +10,7 @@ import MeshRoom from './peer/meshRoom';
 import util from './shared/util';
 import logger from './shared/logger';
 import config from './shared/config';
+import { detect as detectBrowser } from 'detect-browser';
 
 const PeerEvents = new Enum([
   'open',
@@ -471,7 +472,8 @@ class Peer extends EventEmitter {
         ];
 
         // Edge can not handle turns-tcp
-        if (util.detectBrowser() !== 'edge') {
+        const browser = detectBrowser();
+        if (browser && browser.name !== 'edge') {
           turnCombinations.push({ protocol: 'turns', transport: 'tcp' });
         }
 

--- a/src/peer.js
+++ b/src/peer.js
@@ -10,7 +10,6 @@ import MeshRoom from './peer/meshRoom';
 import util from './shared/util';
 import logger from './shared/logger';
 import config from './shared/config';
-import { detect as detectBrowser } from 'detect-browser';
 
 const PeerEvents = new Enum([
   'open',
@@ -472,8 +471,8 @@ class Peer extends EventEmitter {
         ];
 
         // Edge can not handle turns-tcp
-        const browser = detectBrowser();
-        if (browser && browser.name !== 'edge') {
+        const browser = util.detectBrowser();
+        if (browser.name !== 'edge') {
           turnCombinations.push({ protocol: 'turns', transport: 'tcp' });
         }
 

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -1,6 +1,5 @@
 import EventEmitter from 'events';
 import Enum from 'enum';
-import { detect as detectBrowser } from 'detect-browser';
 
 import Negotiator from './negotiator';
 import util from '../shared/util';
@@ -164,15 +163,14 @@ class Connection extends EventEmitter {
    * @private
    */
   _setupNegotiatorMessageHandlers() {
-    const browserInfo = detectBrowser();
-    const browserName = browserInfo ? browserInfo.name : '';
+    const browserInfo = util.detectBrowser();
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
       const connectionAnswer = {
         answer: answer,
         dst: this.remoteId,
         connectionId: this.id,
         connectionType: this.type,
-        browser: browserName,
+        browser: browserInfo,
       };
       this.emit(Connection.EVENTS.answer.key, connectionAnswer);
     });
@@ -184,7 +182,7 @@ class Connection extends EventEmitter {
         connectionId: this.id,
         connectionType: this.type,
         metadata: this.metadata,
-        browser: browserName,
+        browser: browserInfo,
       };
       if (this.serialization) {
         connectionOffer.serialization = this.serialization;

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -100,6 +100,7 @@ class MediaConnection extends Connection {
       videoReceiveEnabled: options.videoReceiveEnabled,
       audioReceiveEnabled: options.audioReceiveEnabled,
     });
+    this._negotiator.setRemoteBrowser(this._options.payload.browser);
     this._pcAvailable = true;
 
     this._handleQueuedMessages();

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -618,9 +618,13 @@ class Negotiator extends EventEmitter {
     }
 
     // HACK: For some reason FF59 doesn't work when Chrome 64 renegotiates after updating the stream.
-    // However, simply updating the localDescription updates the remote stream if the other browser is firefox.
+    // However, simply updating the localDescription updates the remote stream if the other browser is firefox 59+.
     // Chrome 64 probably uses replaceTrack-like functions internally.
-    if (this._remoteBrowser && this._remoteBrowser.name === 'firefox') {
+    const isRemoteBrowserNeedRenegotiation =
+      this._remoteBrowser &&
+      this._remoteBrowser.name === 'firefox' &&
+      this._remoteBrowser.major >= 59;
+    if (isRemoteBrowserNeedRenegotiation) {
       this._pc.addStream(newStream);
 
       // use setTimeout to trigger (and do nothing) on add/removeStream.

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -637,6 +637,9 @@ class Negotiator extends EventEmitter {
             })
             .then(() => {
               return this._pc.setRemoteDescription(this._pc.remoteDescription);
+            })
+            .catch(err => {
+              logger.error(err);
             });
         } else {
           promise = this._pc
@@ -646,6 +649,9 @@ class Negotiator extends EventEmitter {
             })
             .then(answer => {
               return this._pc.setLocalDescription(answer);
+            })
+            .catch(err => {
+              logger.error(err);
             });
         }
         // restore onnegotiationneeded in case we need it later.

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -3,7 +3,7 @@ import Enum from 'enum';
 
 import sdpUtil from '../shared/sdpUtil';
 import logger from '../shared/logger';
-import util from '../shared/util';
+import { detect as detectBrowser } from 'detect-browser';
 
 const NegotiatorEvents = new Enum([
   'addStream',
@@ -62,6 +62,7 @@ class Negotiator extends EventEmitter {
     this._videoCodec = options.videoCodec;
     this._type = options.type;
     this._recvonlyState = this._getReceiveOnlyState(options);
+    this._remoteBrowser = '';
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -92,6 +93,10 @@ class Negotiator extends EventEmitter {
     }
   }
 
+  setRemoteBrowser(browser) {
+    this._remoteBrowser = browser;
+  }
+
   /**
    * Replace the stream being sent with a new one.
    * @param {MediaStream} newStream - The stream to replace the old stream with.
@@ -99,7 +104,7 @@ class Negotiator extends EventEmitter {
   replaceStream(newStream) {
     // If negotiator is null
     // or replaceStream was called but `onnegotiationneeded` event has not finished yet.
-    if (!this._pc || this._replaceStreamCalled) {
+    if (!this._pc) {
       return;
     }
 
@@ -107,7 +112,9 @@ class Negotiator extends EventEmitter {
     // This doesn't require renegotiation.
     if (this._isRtpSenderAvailable && !this._isForceUseStreamMethods) {
       this._replacePerTrack(newStream);
-    } else {
+    } else if (!this._replaceStreamCalled) {
+      // _replacePerStream is used for Chrome 64 and below. All other browsers should have track methods implemented.
+      // We can delete _replacePerStream after Chrome 64 is no longer supported.
       this._replacePerStream(newStream);
     }
   }
@@ -134,6 +141,9 @@ class Negotiator extends EventEmitter {
       })
       .then(answer => {
         this.emit(Negotiator.EVENTS.answerCreated.key, answer);
+      })
+      .catch(err => {
+        logger.error(err);
       });
   }
 
@@ -197,9 +207,13 @@ class Negotiator extends EventEmitter {
     this._isAddTransceiverAvailable =
       typeof RTCPeerConnection.prototype.addTransceiver === 'function';
 
-    // If browser is Chrome, we use addStream/replaceStream instead of addTrack/replaceTrack.
+    // If browser is Chrome 64, we use addStream/replaceStream instead of addTrack/replaceTrack.
     // Because Chrome can't call properly to Firefox using track methods.
-    this._isForceUseStreamMethods = util.detectBrowser() === 'chrome';
+    const browserInfo = detectBrowser();
+    this._isForceUseStreamMethods =
+      browserInfo &&
+      browserInfo.name === 'chrome' &&
+      parseInt(browserInfo.version.split('.')[0]) <= 64;
 
     // Calling RTCPeerConnection with an empty object causes an error
     // Either give it a proper pcConfig or undefined
@@ -549,13 +563,6 @@ class Negotiator extends EventEmitter {
     _updateSenderWithTrack(vSender, vTracks[0], newStream);
     _updateSenderWithTrack(aSender, aTracks[0], newStream);
 
-    this._replaceStreamCalled = true;
-
-    // We don't actually need to do renegotiation but force it in order to prevent
-    // problems with the stream.id being mismatched when renegotiation happens anyways
-    // Firefox 55 doesn't trigger onnegotiationneeded event when a track in a stream is removed
-    this._pc.onnegotiationneeded();
-
     /**
      * Replace a track being sent with a new one.
      * @param {RTCRtpSender} sender - The sender which type is video or audio.
@@ -595,9 +602,6 @@ class Negotiator extends EventEmitter {
   _replacePerStream(newStream) {
     const localStreams = this._pc.getLocalStreams();
 
-    // Temporarily unset onnegotiationneeded so that it doesn't do anything.
-    // Leaving this set will cause an extra negotiation on removeStream that will cause the
-    // signalingState on the answer side to enter an unexpected state, leading to errors.
     const origOnNegotiationNeeded = this._pc.onnegotiationneeded;
     this._pc.onnegotiationneeded = () => {};
 
@@ -606,13 +610,50 @@ class Negotiator extends EventEmitter {
       this._pc.removeStream(localStreams[0]);
     }
 
-    this._replaceStreamCalled = true;
-
-    // a chance to trigger (and do nothing) on removeStream.
-    setTimeout(() => {
+    // HACK: For some reason FF59 doesn't work when Chrome 64 renegotiates after updating the stream.
+    // However, simply updating the localDescription updates the remote stream if the other browser is firefox.
+    // Chrome 64 probably uses replaceTrack-like functions internally.
+    if (this._remoteBrowser === 'firefox') {
       this._pc.addStream(newStream);
-      this._pc.onnegotiationneeded = origOnNegotiationNeeded;
-    });
+
+      // use setTimeout to trigger (and do nothing) on add/removeStream.
+      setTimeout(() => {
+        // update the localDescription with the new stream information (after getting to the right state)
+        let promise;
+        if (this._originator) {
+          promise = this._makeOfferSdp()
+            .then(offer => {
+              return this._pc.setLocalDescription(offer);
+            })
+            .then(() => {
+              return this._pc.setRemoteDescription(this._pc.remoteDescription);
+            });
+        } else {
+          promise = this._pc
+            .setRemoteDescription(this._pc.remoteDescription)
+            .then(() => {
+              return this._pc.createAnswer();
+            })
+            .then(answer => {
+              return this._pc.setLocalDescription(answer);
+            });
+        }
+        // restore onnegotiationneeded in case we need it later.
+        promise.finally(() => {
+          this._pc.onnegotiationneeded = origOnNegotiationNeeded;
+        });
+      });
+    } else {
+      // this is the normal flow where we renegotiate.
+      this._replaceStreamCalled = true;
+
+      // use setTimeout to trigger (and do nothing) on removeStream.
+      setTimeout(() => {
+        // onnegotiationneeded will be triggered by addStream.
+        this._pc.addStream(newStream);
+        this._pc.onnegotiationneeded = origOnNegotiationNeeded;
+      });
+    }
   }
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -634,9 +634,6 @@ class Negotiator extends EventEmitter {
             })
             .then(() => {
               return this._pc.setRemoteDescription(this._pc.remoteDescription);
-            })
-            .catch(err => {
-              logger.error(err);
             });
         } else {
           promise = this._pc
@@ -646,15 +643,17 @@ class Negotiator extends EventEmitter {
             })
             .then(answer => {
               return this._pc.setLocalDescription(answer);
-            })
-            .catch(err => {
-              logger.error(err);
             });
         }
         // restore onnegotiationneeded in case we need it later.
-        promise.finally(() => {
-          this._pc.onnegotiationneeded = origOnNegotiationNeeded;
-        });
+        promise
+          .then(() => {
+            this._pc.onnegotiationneeded = origOnNegotiationNeeded;
+          })
+          .catch(err => {
+            logger.error(err);
+            this._pc.onnegotiationneeded = origOnNegotiationNeeded;
+          });
       });
     } else {
       // this is the normal flow where we renegotiate.

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -4,7 +4,7 @@ import Room from './room';
 import Negotiator from './negotiator';
 import logger from '../shared/logger';
 import sdpUtil from '../shared/sdpUtil';
-import util from '../shared/util';
+import { detect as detectBrowser } from 'detect-browser';
 
 const MessageEvents = ['offerRequest', 'candidate'];
 
@@ -72,7 +72,8 @@ class SFURoom extends Room {
 
     // Chrome and Safari can't handle unified plan messages so convert it to Plan B
     // We don't need to convert the answer back to Unified Plan because the server can handle Plan B
-    if (util.detectBrowser() !== 'firefox') {
+    const browserInfo = detectBrowser();
+    if (browserInfo && browserInfo.name !== 'firefox') {
       offer = sdpUtil.unifiedToPlanB(offer);
     }
 

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -4,7 +4,7 @@ import Room from './room';
 import Negotiator from './negotiator';
 import logger from '../shared/logger';
 import sdpUtil from '../shared/sdpUtil';
-import { detect as detectBrowser } from 'detect-browser';
+import util from '../shared/util';
 
 const MessageEvents = ['offerRequest', 'candidate'];
 
@@ -72,8 +72,8 @@ class SFURoom extends Room {
 
     // Chrome and Safari can't handle unified plan messages so convert it to Plan B
     // We don't need to convert the answer back to Unified Plan because the server can handle Plan B
-    const browserInfo = detectBrowser();
-    if (browserInfo && browserInfo.name !== 'firefox') {
+    const browserInfo = util.detectBrowser();
+    if (browserInfo.name !== 'firefox') {
       offer = sdpUtil.unifiedToPlanB(offer);
     }
 

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1,3 +1,5 @@
+import { detect } from 'detect-browser';
+
 /**
  * Validate the Peer ID format.
  * @param {string} [id] - A Peer ID.
@@ -80,6 +82,21 @@ function isSecure() {
   return location.protocol === 'https:';
 }
 
+/**
+ * Detect browser name and version.
+ * @return {Object} Browser name and major, minor and patch versions. Object is empty if info can't be obtained.
+ */
+function detectBrowser() {
+  const { name, version } = detect();
+  const [major, minor, patch] = version.split('.').map(i => parseInt(i));
+  return {
+    name,
+    major,
+    minor,
+    patch,
+  };
+}
+
 export default {
   validateId,
   validateKey,
@@ -88,4 +105,5 @@ export default {
   joinArrayBuffers,
   blobToArrayBuffer,
   isSecure,
+  detectBrowser,
 };

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -80,27 +80,6 @@ function isSecure() {
   return location.protocol === 'https:';
 }
 
-/**
- * Detect browser.
- * @return {string} Browser name or empty string for not supported.
- */
-function detectBrowser() {
-  const ua = navigator.userAgent;
-
-  switch (true) {
-    case /Edge/.test(ua):
-      return 'edge';
-    case /Chrome/.test(ua):
-      return 'chrome';
-    case /Firefox/.test(ua):
-      return 'firefox';
-    case /Safari\//.test(ua):
-      return 'safari';
-    default:
-      return '';
-  }
-}
-
 export default {
   validateId,
   validateKey,
@@ -109,5 +88,4 @@ export default {
   joinArrayBuffers,
   blobToArrayBuffer,
   isSecure,
-  detectBrowser,
 };

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -38,6 +38,7 @@ describe('MediaConnection', () => {
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
       replaceStream: replaceSpy,
+      setRemoteBrowser: sinon.spy(),
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -362,12 +362,6 @@ describe('Negotiator', () => {
 
           assert.equal(videoSender.replaceTrack.callCount, 0);
         });
-
-        it('should call onnegotiationneeded', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(negotiationNeededStub.callCount, 1);
-        });
       });
 
       describe('new stream has fewer number of tracks', () => {
@@ -382,12 +376,6 @@ describe('Negotiator', () => {
           assert.equal(removeTrackStub.callCount, 2);
           assert(removeTrackStub.calledWith(audioSender));
           assert(removeTrackStub.calledWith(videoSender));
-        });
-
-        it('should call onnegotiationneeded', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(negotiationNeededStub.callCount, 1);
         });
       });
 
@@ -415,12 +403,6 @@ describe('Negotiator', () => {
           negotiator.replaceStream(newStream);
 
           assert(addTrackStub.calledWith(videoTrack));
-        });
-
-        it('should call onnegotiationneeded', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(negotiationNeededStub.callCount, 1);
         });
       });
     });

--- a/tests/shared/util.js
+++ b/tests/shared/util.js
@@ -89,11 +89,4 @@ describe('Util', () => {
       assert(util.isSecure(location.protocol) === false);
     });
   });
-
-  describe('detectBrowser', () => {
-    // Karma only runs on 'chrome'
-    it('should return chrome', () => {
-      assert(util.detectBrowser() === 'chrome');
-    });
-  });
 });

--- a/tests/shared/util.js
+++ b/tests/shared/util.js
@@ -89,4 +89,18 @@ describe('Util', () => {
       assert(util.isSecure(location.protocol) === false);
     });
   });
+
+  describe('detectBrowser', () => {
+    // Karma only runs on 'chrome'
+    it('should return chrome', () => {
+      assert(util.detectBrowser().name === 'chrome');
+    });
+
+    it('should return major, minor and patch versions', () => {
+      const { major, minor, patch } = util.detectBrowser();
+      assert(typeof major === 'number');
+      assert(typeof minor === 'number');
+      assert(typeof patch === 'number');
+    });
+  });
 });


### PR DESCRIPTION
The current implementation of replaceStream was incompatible between FF 59 and Chrome 64 due to bugs in both browsers.
When replacing streams, take different paths on Chrome 64 based on whether the opposing browser is firefox or not.
Also use replaceTrack for Chrome 65+ as it is finally being implemented.

edit: updated so chrome 64 only takes a different path for ff48 or less.

--- 
known issues:
- remote stream freezes on iOS/Android sdk when replaceStream is called on Chrome 64
- remote stream freezes in an SFU room when using FF59 and replaceStream is called on Chrome 64
- remote stream freezes on FF58 when replaceStream is called on Chrome 64, then FF58
  - it starts working again when replaceStream is called on Chrome 64 again