### PR TITLE
Fix missing `this` ref

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -336,7 +336,7 @@ class Negotiator extends EventEmitter {
       // Note that this code very rarely applies the old remote offer.
       // E.g. "Offer A -> Offer B" should be the right order but for some reason like NW unstablity,
       //      offerQueue might keep "Offer B" first and handle "Offer A" later.
-      if (this._pc.signalingState === 'stable') {
+      if (pc.signalingState === 'stable') {
         const offer = this._offerQueue.shift();
         if (offer) {
           this.handleOffer(offer);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6259812/39469111-aa9e7890-4d71-11e8-8e8d-040a94e02c5f.png)

When `Room#close()` is called, `this._pc` turns to be `null`.
At the same time `signalingState` is changed to `closed` and `signalingstatechange` event fires, finally this error is raised.

See this [repro](https://jsbin.com/cibuquqeta/edit?js,console).