### PR TITLE
[WIP] Remove stream-based methods and events

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -78,7 +78,6 @@ class Connection extends EventEmitter {
   handleAnswer(answerMessage) {
     if (this._pcAvailable) {
       this._negotiator.handleAnswer(answerMessage.answer);
-      this._negotiator.setRemoteBrowser(answerMessage.browser);
       this.open = true;
     } else {
       logger.log(`Queuing ANSWER message in ${this.id} from ${this.remoteId}`);
@@ -163,14 +162,12 @@ class Connection extends EventEmitter {
    * @private
    */
   _setupNegotiatorMessageHandlers() {
-    const browserInfo = util.detectBrowser();
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
       const connectionAnswer = {
         answer: answer,
         dst: this.remoteId,
         connectionId: this.id,
         connectionType: this.type,
-        browser: browserInfo,
       };
       this.emit(Connection.EVENTS.answer.key, connectionAnswer);
     });
@@ -182,7 +179,6 @@ class Connection extends EventEmitter {
         connectionId: this.id,
         connectionType: this.type,
         metadata: this.metadata,
-        browser: browserInfo,
       };
       if (this.serialization) {
         connectionOffer.serialization = this.serialization;

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -71,11 +71,6 @@ class DataConnection extends Connection {
     // Messages stored by peer because DC was not ready yet
     this._queuedMessages = this._options.queuedMessages || [];
 
-    // Maybe don't need this anymore
-    if (this._options.payload) {
-      this._peerBrowser = this._options.payload.browser;
-    }
-
     // This replaces the PeerJS 'initialize' method
     this._negotiator.on(Negotiator.EVENTS.dcCreated.key, dc => {
       this._dc = dc;

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -100,7 +100,6 @@ class MediaConnection extends Connection {
       videoReceiveEnabled: options.videoReceiveEnabled,
       audioReceiveEnabled: options.audioReceiveEnabled,
     });
-    this._negotiator.setRemoteBrowser(this._options.payload.browser);
     this._pcAvailable = true;
 
     this._handleQueuedMessages();

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -4,7 +4,7 @@ import Negotiator from './negotiator';
 import Connection from './connection';
 import logger from '../shared/logger';
 
-const MCEvents = new Enum(['stream', 'removeStream']);
+const MCEvents = new Enum(['stream']);
 
 MCEvents.extend(Connection.EVENTS.enums);
 
@@ -134,16 +134,6 @@ class MediaConnection extends Connection {
 
       this.emit(MediaConnection.EVENTS.stream.key, remoteStream);
     });
-
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, remoteStream => {
-      logger.log('Stream removed', remoteStream);
-
-      // Don't unset if a new stream has already replaced the old one
-      if (this.remoteStream === remoteStream) {
-        this.remoteStream = null;
-      }
-      this.emit(MediaConnection.EVENTS.removeStream.key, remoteStream);
-    });
   }
 
   /**
@@ -158,13 +148,6 @@ class MediaConnection extends Connection {
    * MediaStream received from peer.
    *
    * @event MediaConnection#stream
-   * @type {MediaStream}
-   */
-
-  /**
-   * MediaStream from peer was removed.
-   *
-   * @event MediaConnection#removeStream
    * @type {MediaStream}
    */
 }

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -371,10 +371,6 @@ class MeshRoom extends Room {
         remoteStream.peerId = connection.remoteId;
         this.emit(MeshRoom.EVENTS.stream.key, remoteStream);
       });
-
-      connection.on(MediaConnection.EVENTS.removeStream.key, remoteStream => {
-        this.emit(MeshRoom.EVENTS.removeStream.key, remoteStream);
-      });
     }
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -31,7 +31,6 @@ class Negotiator extends EventEmitter {
     super();
     this._offerQueue = [];
     this._isExpectingAnswer = false;
-    this._replaceStreamCalled = false;
     this._isNegotiationAllowed = true;
   }
 
@@ -311,11 +310,7 @@ class Negotiator extends EventEmitter {
             this._setLocalDescription(offer);
             this.emit(Negotiator.EVENTS.negotiationNeeded.key);
           });
-        } else if (this._replaceStreamCalled) {
-          this.handleOffer();
         }
-
-        this._replaceStreamCalled = false;
       }
     };
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -63,7 +63,6 @@ class Negotiator extends EventEmitter {
     this._videoCodec = options.videoCodec;
     this._type = options.type;
     this._recvonlyState = this._getReceiveOnlyState(options);
-    this._remoteBrowser = {};
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -92,10 +91,6 @@ class Negotiator extends EventEmitter {
     } else {
       this.handleOffer(options.offer);
     }
-  }
-
-  setRemoteBrowser(browser) {
-    this._remoteBrowser = browser;
   }
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -6,7 +6,6 @@ import logger from '../shared/logger';
 
 const NegotiatorEvents = new Enum([
   'addStream',
-  'removeStream',
   'dcCreated',
   'offerCreated',
   'answerCreated',
@@ -321,11 +320,6 @@ class Negotiator extends EventEmitter {
           });
         }
       }
-    };
-
-    pc.onremovestream = evt => {
-      logger.log('`removestream` triggered');
-      this.emit(Negotiator.EVENTS.removeStream.key, evt.stream);
     };
 
     pc.onsignalingstatechange = () => {

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -3,7 +3,6 @@ import Enum from 'enum';
 
 const Events = [
   'stream',
-  'removeStream',
   'open',
   'close',
   'peerJoin',

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -126,14 +126,6 @@ class SFURoom extends Room {
       }
     });
 
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-      delete this.remoteStreams[stream.id];
-      delete this._msidMap[stream.id];
-      delete this._unknownStreams[stream.id];
-
-      this.emit(SFURoom.EVENTS.removeStream.key, stream);
-    });
-
     this._negotiator.on(Negotiator.EVENTS.negotiationNeeded.key, () => {
       // Renegotiate by requesting an offer then sending an answer when one is created.
       const offerRequestMessage = {

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -74,14 +74,12 @@ describe('DataConnection', () => {
       const label = 'label';
       const dcInit = { ordered: false };
       const serialization = 'binary';
-      const peerBrowser = 'browser';
       const metadata = 'meta';
       const options = {
         label: label,
         dcInit: dcInit,
         serialization: serialization,
         metadata: metadata,
-        payload: { browser: peerBrowser },
       };
 
       const dc = new DataConnection(id, options);
@@ -92,7 +90,6 @@ describe('DataConnection', () => {
       assert.equal(dc.dcInit, dcInit);
       assert.equal(dc.serialization, serialization);
       assert.equal(dc.metadata, metadata);
-      assert.equal(dc._peerBrowser, peerBrowser);
       assert.equal(dc._options, options);
     });
   });

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -180,45 +180,6 @@ describe('MediaConnection', () => {
 
       spy.restore();
     });
-
-    it("should set remoteStream to null on 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = remoteStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert.equal(mc.remoteStream, null);
-    });
-
-    it("should not change remoteStream on 'removeStream' being emitted if remoteStream is different", () => {
-      const origStream = {};
-      const removeStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = origStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, removeStream);
-
-      assert.equal(mc.remoteStream, origStream);
-    });
-
-    it("should emit a 'removeStream' event upon 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-
-      const spy = sinon.spy(mc, 'emit');
-
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert(mc);
-      assert(spy.calledOnce);
-      assert(
-        spy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          remoteStream
-        ) === true
-      );
-
-      spy.restore();
-    });
   });
 
   describe('replaceStream', () => {

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -555,20 +555,6 @@ describe('MeshRoom', () => {
       );
     });
 
-    it('should handle stream and removeStream events if connection is a MediaConnection', () => {
-      meshRoom._setupMessageHandlers({ on: onSpy, type: 'media' });
-
-      assert(
-        onSpy.calledWith(MediaConnection.EVENTS.stream.key, sinon.match.func)
-      );
-      assert(
-        onSpy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          sinon.match.func
-        )
-      );
-    });
-
     describe('Event handlers', () => {
       const remoteId = 'remoteId';
       let mc;
@@ -653,20 +639,6 @@ describe('MeshRoom', () => {
           });
 
           mc.emit(MediaConnection.EVENTS.stream.key, stream);
-        });
-      });
-
-      describe('removeStream', () => {
-        it('should emit stream', done => {
-          const stream = {};
-
-          meshRoom.on(MeshRoom.EVENTS.removeStream.key, emittedStream => {
-            assert.equal(emittedStream, stream);
-
-            done();
-          });
-
-          mc.emit(MediaConnection.EVENTS.removeStream.key, stream);
         });
       });
     });

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -653,7 +653,6 @@ describe('Negotiator', () => {
       assert.equal(typeof pc.onicecandidate, 'function');
       assert.equal(typeof pc.oniceconnectionstatechange, 'function');
       assert.equal(typeof pc.onnegotiationneeded, 'function');
-      assert.equal(typeof pc.onremovestream, 'function');
       assert.equal(typeof pc.onsignalingstatechange, 'function');
     });
 
@@ -787,33 +786,6 @@ describe('Negotiator', () => {
             });
             pc.onnegotiationneeded();
           });
-        });
-      });
-
-      describe('onremovestream', () => {
-        const evt = { stream: 'stream' };
-        let logSpy;
-
-        beforeEach(() => {
-          logSpy = sinon.spy(logger, 'log');
-        });
-
-        afterEach(() => {
-          logSpy.restore();
-        });
-
-        it('should log the event', () => {
-          pc.onremovestream(evt);
-          logSpy.calledWith('`removestream` triggered');
-        });
-
-        it("should emit 'removeStream'", done => {
-          negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-            assert.equal(stream, evt.stream);
-            done();
-          });
-
-          pc.onremovestream(evt);
         });
       });
     });

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -105,7 +105,6 @@ describe('SFURoom', () => {
       sfuRoom._setupNegotiatorMessageHandlers();
 
       assert(onSpy.calledWith(Negotiator.EVENTS.addStream.key));
-      assert(onSpy.calledWith(Negotiator.EVENTS.removeStream.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceCandidate.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.answerCreated.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceConnectionFailed.key));
@@ -173,50 +172,6 @@ describe('SFURoom', () => {
 
             assert.deepEqual(sfuRoom._unknownStreams, { [stream.id]: stream });
           });
-        });
-      });
-
-      describe('removeStream', () => {
-        const stream = { id: 'streamId', peerId: peerId };
-        const otherStream = { id: 'otherStream', peerId: remotePeerId };
-
-        it('should delete the stream from remoteStreams', () => {
-          sfuRoom.remoteStreams[stream.id] = stream;
-          sfuRoom.remoteStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom.remoteStreams[stream.id], undefined);
-          assert.equal(sfuRoom.remoteStreams[otherStream.id], otherStream);
-        });
-
-        it('should delete the stream from _msidMap', () => {
-          sfuRoom._msidMap[stream.id] = stream.peerId;
-          sfuRoom._msidMap[otherStream.id] = otherStream.peerId;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._msidMap[stream.id], undefined);
-          assert.equal(sfuRoom._msidMap[otherStream.id], otherStream.peerId);
-        });
-
-        it('should delete the stream from _unknownStreams', () => {
-          sfuRoom._unknownStreams[stream.id] = stream;
-          sfuRoom._unknownStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._unknownStreams[stream.id], undefined);
-          assert.equal(sfuRoom._unknownStreams[otherStream.id], otherStream);
-        });
-
-        it('should emit a removeStream event', done => {
-          sfuRoom.on(SFURoom.EVENTS.removeStream.key, removedStream => {
-            assert.equal(removedStream, stream);
-            done();
-          });
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
         });
       });
 


### PR DESCRIPTION
### Changes
- Use track-based methods and events instead of stream-based
- Remove `(Mesh|SFU)Room.on('removeStream')` event

<details>

### TODOs
- Source
  - [x] replaceStream aka (add|remove)Stream
  - [x] addStream
  - [x] removeStream
  - [x] pc.onaddstream
  - [x] pc.onremovestream
  - [x] related things 
- [x] Tests
- [x] Check on browser
  - [x] p2p-videochat
  - [x] p2p-broadcast
  - [x] fullmesh-videochat
  - [x] sfu-videochat
  - [x] skyway-conf-dev

</details>