### PR TITLE
Check xhr status before JSON.parse()

### DIFF
--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -164,8 +164,12 @@ class Socket extends EventEmitter {
       http.open('GET', this._dispatcherUrl, true);
 
       /* istanbul ignore next */
-      http.onerror = function() {
+      http.onerror = () => {
         reject(new Error('There was a problem with the dispatcher.'));
+      };
+
+      http.onabort = () => {
+        reject(new Error('The request aborted.'));
       };
 
       http.ontimeout = () => {
@@ -174,6 +178,12 @@ class Socket extends EventEmitter {
 
       http.onreadystatechange = () => {
         if (http.readyState !== 4) {
+          return;
+        }
+
+        // maybe aborted or something
+        if (http.status === 0) {
+          reject(new Error('There was a problem with the dispatcher.'));
           return;
         }
 


### PR DESCRIPTION
This PR will fix the issue happens when XHR is aborted during `_getSignalingServer()`.