### PR TITLE
Revert "Revert "Check xhr status before JSON.parse()""

### DIFF
--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -164,8 +164,12 @@ class Socket extends EventEmitter {
       http.open('GET', this._dispatcherUrl, true);
 
       /* istanbul ignore next */
-      http.onerror = function() {
+      http.onerror = () => {
         reject(new Error('There was a problem with the dispatcher.'));
+      };
+
+      http.onabort = () => {
+        reject(new Error('The request aborted.'));
       };
 
       http.ontimeout = () => {
@@ -174,6 +178,12 @@ class Socket extends EventEmitter {
 
       http.onreadystatechange = () => {
         if (http.readyState !== 4) {
+          return;
+        }
+
+        // maybe aborted or something
+        if (http.status === 0) {
+          reject(new Error('There was a problem with the dispatcher.'));
           return;
         }
 


### PR DESCRIPTION
This reverts commit 2967d4ed6fda4ba20513f1964d92880e7c754154.
Maybe I should revert merge commit (it means 5e370aa896451866762625a66b4c0864e182b036 as #85), but I couldn't revert that since GitHub lose parent-number on reverting merge commit.