### PR TITLE
Fix/handle queue issue

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -94,7 +94,7 @@ class Connection extends EventEmitter {
    * @param {object} candidateMessage - Message object containing a candidate.
    */
   handleCandidate(candidateMessage) {
-    if (this._pcAvailable) {
+    if (this._negotiator.hasRemoteDescription()) {
       this._negotiator.handleCandidate(candidateMessage.candidate);
     } else {
       logger.log(
@@ -220,6 +220,10 @@ class Connection extends EventEmitter {
         connectionType: this.type,
       };
       this.emit(Connection.EVENTS.candidate.key, connectionCandidate);
+    });
+
+    this._negotiator.on(Negotiator.EVENTS.handleQueue.key, () => {
+      this._handleQueuedMessages();
     });
 
     this._negotiator.on(Negotiator.EVENTS.iceConnectionFailed.key, () => {

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -124,6 +124,22 @@ class Connection extends EventEmitter {
    * @private
    */
   _handleQueuedMessages() {
+    // Skip if there're no answer SDPs in the queue and setRemoteDescription() hasn't been resolved,
+    // because in that case we're not ready to start to process the remote candidates.
+    if (!this._negotiator.hasRemoteDescription()) {
+      const hasAnswerSdp = this._queuedMessages.some(
+        message => message.type === config.MESSAGE_TYPES.SERVER.ANSWER.key
+      );
+      if (!hasAnswerSdp) {
+        return;
+      }
+    }
+
+    // Sort to handle ANSWER first.
+    this._queuedMessages.sort(
+      message =>
+        message.type === config.MESSAGE_TYPES.SERVER.ANSWER.key ? -1 : 1
+    );
     for (const message of this._queuedMessages) {
       switch (message.type) {
         case config.MESSAGE_TYPES.SERVER.ANSWER.key:

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -16,6 +16,7 @@ const NegotiatorEvents = new Enum([
   'iceConnectionFailed',
   'negotiationNeeded',
   'error',
+  'handleQueue',
 ]);
 
 /**
@@ -65,6 +66,7 @@ class Negotiator extends EventEmitter {
     this._type = options.type;
     this._recvonlyState = this._getReceiveOnlyState(options);
     this._remoteBrowser = {};
+    this._hasRemoteDescription = false;
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -189,6 +191,14 @@ class Negotiator extends EventEmitter {
       .catch(e => {
         logger.error('Failed to add ICE candidate', e);
       });
+  }
+
+  /**
+   * Return true if setRemoteDescription resolved.
+   * @returns {boolean} true if setRemoteDescription resolved
+   */
+  hasRemoteDescription() {
+    return this._hasRemoteDescription;
   }
 
   /**
@@ -506,6 +516,8 @@ class Negotiator extends EventEmitter {
       .setRemoteDescription(new RTCSessionDescription(sdp))
       .then(() => {
         logger.log('Set remoteDescription:', sdp.type);
+        this._hasRemoteDescription = true;
+        this.emit(Negotiator.EVENTS.handleQueue.key);
         return Promise.resolve();
       })
       .catch(error => {

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -38,6 +38,9 @@ describe('DataConnection', () => {
       cleanup: cleanupSpy,
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
+      hasRemoteDescription: function() {
+        return true;
+      },
     });
     // hoist statics
     negotiatorStub.EVENTS = Negotiator.EVENTS;

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -18,6 +18,7 @@ describe('DataConnection', () => {
   let cleanupSpy;
   let answerSpy;
   let candidateSpy;
+  let hasRemoteDescriptionStub;
 
   beforeEach(() => {
     // Negotiator stub and spies
@@ -26,6 +27,7 @@ describe('DataConnection', () => {
     cleanupSpy = sinon.spy();
     answerSpy = sinon.spy();
     candidateSpy = sinon.spy();
+    hasRemoteDescriptionStub = sinon.stub().returns(false);
 
     negotiatorStub.returns({
       on: function(event, callback) {
@@ -38,9 +40,7 @@ describe('DataConnection', () => {
       cleanup: cleanupSpy,
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
-      hasRemoteDescription: function() {
-        return true;
-      },
+      hasRemoteDescription: hasRemoteDescriptionStub,
     });
     // hoist statics
     negotiatorStub.EVENTS = Negotiator.EVENTS;
@@ -55,6 +55,7 @@ describe('DataConnection', () => {
     cleanupSpy.resetHistory();
     answerSpy.resetHistory();
     candidateSpy.resetHistory();
+    hasRemoteDescriptionStub.resetBehavior();
   });
 
   describe('Constructor', () => {
@@ -172,6 +173,7 @@ describe('DataConnection', () => {
       const spy2 = sinon.spy();
       sinon.stub(DataConnection.prototype, 'handleAnswer').callsFake(spy1);
       sinon.stub(DataConnection.prototype, 'handleCandidate').callsFake(spy2);
+      hasRemoteDescriptionStub.returns(true);
 
       const dc = new DataConnection('remoteId', { queuedMessages: messages });
 

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -16,6 +16,7 @@ describe('MediaConnection', () => {
   let cleanupSpy;
   let answerSpy;
   let candidateSpy;
+  let hasRemoteDescriptionStub;
   let replaceSpy;
 
   beforeEach(() => {
@@ -24,6 +25,7 @@ describe('MediaConnection', () => {
     cleanupSpy = sinon.spy();
     answerSpy = sinon.spy();
     candidateSpy = sinon.spy();
+    hasRemoteDescriptionStub = sinon.stub().returns(false);
     replaceSpy = sinon.spy();
 
     stub.returns({
@@ -37,6 +39,7 @@ describe('MediaConnection', () => {
       cleanup: cleanupSpy,
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
+      hasRemoteDescription: hasRemoteDescriptionStub,
       replaceStream: replaceSpy,
       setRemoteBrowser: sinon.spy(),
     });
@@ -53,6 +56,7 @@ describe('MediaConnection', () => {
     cleanupSpy.resetHistory();
     answerSpy.resetHistory();
     candidateSpy.resetHistory();
+    hasRemoteDescriptionStub.resetBehavior();
     replaceSpy.resetHistory();
   });
 
@@ -260,6 +264,7 @@ describe('MediaConnection', () => {
 
       const mc = new MediaConnection('remoteId', { stream: {} });
       mc._pcAvailable = true;
+      hasRemoteDescriptionStub.returns(true);
 
       assert(candidateSpy.called === false);
 

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -16,8 +16,8 @@ describe('MediaConnection', () => {
   let cleanupSpy;
   let answerSpy;
   let candidateSpy;
-  let hasRemoteDescriptionStub;
   let replaceSpy;
+  let hasRemoteDescriptionStub;
 
   beforeEach(() => {
     stub = sinon.stub();
@@ -25,8 +25,8 @@ describe('MediaConnection', () => {
     cleanupSpy = sinon.spy();
     answerSpy = sinon.spy();
     candidateSpy = sinon.spy();
-    hasRemoteDescriptionStub = sinon.stub().returns(false);
     replaceSpy = sinon.spy();
+    hasRemoteDescriptionStub = sinon.stub().returns(false);
 
     stub.returns({
       on: function(event, callback) {
@@ -39,12 +39,9 @@ describe('MediaConnection', () => {
       cleanup: cleanupSpy,
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
-      hasRemoteDescription: hasRemoteDescriptionStub,
       replaceStream: replaceSpy,
       setRemoteBrowser: sinon.spy(),
-      hasRemoteDescription: function() {
-        return true;
-      },
+      hasRemoteDescription: hasRemoteDescriptionStub,
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;
@@ -59,8 +56,8 @@ describe('MediaConnection', () => {
     cleanupSpy.resetHistory();
     answerSpy.resetHistory();
     candidateSpy.resetHistory();
-    hasRemoteDescriptionStub.resetBehavior();
     replaceSpy.resetHistory();
+    hasRemoteDescriptionStub.resetBehavior();
   });
 
   describe('Constructor', () => {
@@ -262,17 +259,14 @@ describe('MediaConnection', () => {
       assert(answerSpy.calledOnce === true);
     });
 
-    it("should call negotiator's handleCandidate with a candidate", () => {
-      const candidate = 'message';
-
+    it("should not call negotiator's handleCandidate before calling handleAnswer", () => {
       const mc = new MediaConnection('remoteId', { stream: {} });
       mc._pcAvailable = true;
-      hasRemoteDescriptionStub.returns(true);
 
       assert(candidateSpy.called === false);
 
-      mc.handleCandidate(candidate);
-      assert(candidateSpy.calledOnce === true);
+      mc.handleCandidate('message');
+      assert(candidateSpy.calledOnce === false);
     });
   });
 
@@ -328,6 +322,8 @@ describe('MediaConnection', () => {
     });
 
     it('should not process any invalid queued messages', () => {
+      hasRemoteDescriptionStub.returns(true);
+
       const messages = [{ type: 'WRONG', payload: 'message' }];
 
       const mc = new MediaConnection('remoteId', {

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -42,6 +42,9 @@ describe('MediaConnection', () => {
       hasRemoteDescription: hasRemoteDescriptionStub,
       replaceStream: replaceSpy,
       setRemoteBrowser: sinon.spy(),
+      hasRemoteDescription: function() {
+        return true;
+      },
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;


### PR DESCRIPTION
- `Negotiator#hasRemoteDesciption()`
  - reverted in the latest release, but finally, we add this again
- to ensure handling ANSWER first, before handling CANDIDATE on processing queued messages