### PR TITLE
Eliminate all side effects inside constructor calls

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -121,6 +121,7 @@ class Peer extends EventEmitter {
     options.stream = stream;
     options.pcConfig = this._pcConfig;
     const mc = new MediaConnection(peerId, options);
+    mc.startConnection();
     logger.log('MediaConnection created in call method');
     this._addConnection(peerId, mc);
     return mc;
@@ -554,8 +555,10 @@ class Peer extends EventEmitter {
           queuedMessages: this._queuedMessages[connectionId],
           pcConfig: this._pcConfig,
         });
+        connection.startConnection();
 
         logger.log('MediaConnection created in OFFER');
+
         this._addConnection(offerMessage.src, connection);
         this.emit(Peer.EVENTS.call.key, connection);
       } else if (offerMessage.connectionType === 'data') {

--- a/src/peer.js
+++ b/src/peer.js
@@ -145,6 +145,7 @@ class Peer extends EventEmitter {
 
     options.pcConfig = this._pcConfig;
     const connection = new DataConnection(peerId, options);
+    connection.startConnection();
     logger.log('DataConnection created in connect method');
     this._addConnection(peerId, connection);
     return connection;
@@ -568,6 +569,7 @@ class Peer extends EventEmitter {
           queuedMessages: this._queuedMessages[connectionId],
           pcConfig: this._pcConfig,
         });
+        connection.startConnection();
 
         logger.log('DataConnection created in OFFER');
 

--- a/src/peer.js
+++ b/src/peer.js
@@ -609,6 +609,8 @@ class Peer extends EventEmitter {
       if (connection) {
         connection.handleAnswer(answerMessage);
       } else {
+        // Should we remove this storing
+        // because answer should be handled immediately after its arrival?
         this._storeMessage(
           config.MESSAGE_TYPES.SERVER.ANSWER.key,
           answerMessage
@@ -639,6 +641,8 @@ class Peer extends EventEmitter {
         if (connection) {
           connection.handleCandidate(candidateMessage);
         } else {
+          // Store candidate in the queue so that the candidate can be added
+          // after setRemoteDescription completed.
           this._storeMessage(
             config.MESSAGE_TYPES.SERVER.CANDIDATE.key,
             candidateMessage

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -126,6 +126,8 @@ class Connection extends EventEmitter {
   _handleQueuedMessages() {
     for (const message of this._queuedMessages) {
       switch (message.type) {
+        // Should we remove this ANSWER block
+        // because ANSWER should be handled immediately?
         case config.MESSAGE_TYPES.SERVER.ANSWER.key:
           this.handleAnswer(message.payload);
           break;

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -93,8 +93,10 @@ class DataConnection extends Connection {
     if (this._options.payload) {
       this._options.payload.pcConfig = this._options.pcConfig;
     }
+  }
 
-    this._negotiator.startConnection(
+  async startConnection() {
+    await this._negotiator.startConnection(
       this._options.payload || {
         originator: true,
         type: 'data',
@@ -103,8 +105,8 @@ class DataConnection extends Connection {
         pcConfig: this._options.pcConfig,
       }
     );
-    this._pcAvailable = true;
 
+    this._pcAvailable = true;
     this._handleQueuedMessages();
   }
 

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -95,6 +95,10 @@ class DataConnection extends Connection {
     }
   }
 
+  /**
+   * Start connection via negotiator and handle queued messages.
+   * @return {Promise<void>} Promise that resolves when starting is done.
+   */
   async startConnection() {
     await this._negotiator.startConnection(
       this._options.payload || {

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -46,23 +46,32 @@ class MediaConnection extends Connection {
     // Messages stored by peer because MC was not ready yet
     this._queuedMessages = this._options.queuedMessages || [];
     this._pcAvailable = false;
+  }
 
-    if (this._options.originator) {
-      this._negotiator.startConnection({
-        type: 'media',
-        stream: this.localStream,
-        originator: this._options.originator,
-        pcConfig: this._options.pcConfig,
-        videoBandwidth: this._options.videoBandwidth,
-        audioBandwidth: this._options.audioBandwidth,
-        videoCodec: this._options.videoCodec,
-        audioCodec: this._options.audioCodec,
-        videoReceiveEnabled: this._options.videoReceiveEnabled,
-        audioReceiveEnabled: this._options.audioReceiveEnabled,
-      });
-      this._pcAvailable = true;
-      this._handleQueuedMessages();
+  /**
+   * Start connection via negotiator and handle queued messages.
+   * @return {Promise<void>} Promise that resolves when starting is done.
+   */
+  async startConnection() {
+    if (!this._options.originator) {
+      return;
     }
+
+    await this._negotiator.startConnection({
+      type: 'media',
+      stream: this.localStream,
+      originator: this._options.originator,
+      pcConfig: this._options.pcConfig,
+      videoBandwidth: this._options.videoBandwidth,
+      audioBandwidth: this._options.audioBandwidth,
+      videoCodec: this._options.videoCodec,
+      audioCodec: this._options.audioCodec,
+      videoReceiveEnabled: this._options.videoReceiveEnabled,
+      audioReceiveEnabled: this._options.audioReceiveEnabled,
+    });
+
+    this._pcAvailable = true;
+    this._handleQueuedMessages();
   }
 
   /**

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -162,6 +162,8 @@ class MeshRoom extends Room {
         metadata: offerMessage.metadata,
         pcConfig: this._pcConfig,
       });
+      connection.startConnection();
+
       logger.log('MediaConnection created in OFFER');
       this._addConnection(offerMessage.src, connection);
       this._setupMessageHandlers(connection);
@@ -302,7 +304,6 @@ class MeshRoom extends Room {
         switch (type) {
           case 'data':
             connection = new DataConnection(peerId, options);
-            connection.startConnection();
             break;
           case 'media':
             connection = new MediaConnection(peerId, options);
@@ -311,6 +312,7 @@ class MeshRoom extends Room {
             return;
         }
 
+        connection.startConnection();
         this._addConnection(peerId, connection);
         this._setupMessageHandlers(connection);
 

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -5,6 +5,7 @@ import Connection from './connection';
 import MediaConnection from './mediaConnection';
 import DataConnection from './dataConnection';
 import logger from '../shared/logger';
+import config from '../shared/config';
 
 const MessageEvents = ['broadcastByDC', 'getPeers'];
 
@@ -36,6 +37,9 @@ class MeshRoom extends Room {
     super(name, peerId, options);
 
     this.connections = {};
+
+    // messages(candidates) received before connection is ready
+    this._queuedMessages = {};
   }
 
   /**
@@ -160,6 +164,7 @@ class MeshRoom extends Room {
         connectionId: connectionId,
         payload: offerMessage,
         metadata: offerMessage.metadata,
+        queuedMessages: this._queuedMessages[connectionId],
         pcConfig: this._pcConfig,
       });
       connection.startConnection();
@@ -222,6 +227,15 @@ class MeshRoom extends Room {
 
     if (connection) {
       connection.handleCandidate(candidateMessage);
+    } else {
+      // Looks like PeerConnection hasn't completed setRemoteDescription
+      if (!this._queuedMessages[candidateMessage.connectionId]) {
+        this._queuedMessages[candidateMessage.connectionId] = [];
+      }
+      this._queuedMessages[candidateMessage.connectionId].push({
+        type: config.MESSAGE_TYPES.SERVER.CANDIDATE.key,
+        payload: candidateMessage,
+      });
     }
   }
 

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -229,7 +229,7 @@ class MeshRoom extends Room {
       connection.handleCandidate(candidateMessage);
     } else {
       // Looks like PeerConnection hasn't completed setRemoteDescription
-      if (!this._queuedMessages[candidateMessage.connectionId]) {
+      if (this._queuedMessages[candidateMessage.connectionId] === undefined) {
         this._queuedMessages[candidateMessage.connectionId] = [];
       }
       this._queuedMessages[candidateMessage.connectionId].push({

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -302,6 +302,7 @@ class MeshRoom extends Room {
         switch (type) {
           case 'data':
             connection = new DataConnection(peerId, options);
+            connection.startConnection();
             break;
           case 'media':
             connection = new MediaConnection(peerId, options);

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -79,7 +79,7 @@ class Negotiator extends EventEmitter {
       } else if (this._originator) {
         // This means the peer wants to create offer SDP with `recvonly`
         const offer = await this._makeOfferSdp();
-        this._setLocalDescription(offer);
+        await this._setLocalDescription(offer);
       }
     }
 
@@ -91,7 +91,7 @@ class Negotiator extends EventEmitter {
         this.emit(Negotiator.EVENTS.dcCreated.key, dc);
       }
     } else {
-      this.handleOffer(options.offer);
+      await this.handleOffer(options.offer);
     }
   }
 

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -55,13 +55,6 @@ describe('DataConnection', () => {
   });
 
   describe('Constructor', () => {
-    it("should not call negotiator's startConnection method when created", () => {
-      const dc = new DataConnection('remoteId', {});
-
-      assert(dc);
-      assert(startSpy.notCalled);
-    });
-
     it('should store any messages passed in when created', () => {
       const dc = new DataConnection('remoteId', {
         queuedMessages: ['message'],
@@ -95,6 +88,22 @@ describe('DataConnection', () => {
       assert.equal(dc._peerBrowser, peerBrowser);
       assert.equal(dc._options, options);
     });
+
+    it('should throw an error if serialization is not valid', done => {
+      let dc;
+      try {
+        dc = new DataConnection('remoteId', { serialization: 'foobar' });
+      } catch (e) {
+        assert(dc === undefined);
+        done();
+      }
+    });
+
+    it('default serialization should be binary', () => {
+      const dc = new DataConnection('remoteId', {});
+
+      assert(dc.serialization === 'binary');
+    });
   });
 
   describe('Initialize', () => {
@@ -108,22 +117,6 @@ describe('DataConnection', () => {
       assert(dc._dc.onopen);
       assert(dc._dc.onmessage);
       assert(dc._dc.onclose);
-    });
-
-    it('default serialization should be binary', () => {
-      const dc = new DataConnection('remoteId', {});
-
-      assert(dc.serialization === 'binary');
-    });
-
-    it('should throw an error if serialization is not valid', done => {
-      let dc;
-      try {
-        dc = new DataConnection('remoteId', { serialization: 'foobar' });
-      } catch (e) {
-        assert(dc === undefined);
-        done();
-      }
     });
 
     it('should open the DataConnection and emit upon _dc.onopen()', () => {

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -59,7 +59,7 @@ describe('DataConnection', () => {
       const dc = new DataConnection('remoteId', {});
 
       assert(dc);
-      assert(startSpy.calledOnce === false);
+      assert(startSpy.notCalled);
     });
 
     it('should store any messages passed in when created', () => {

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -57,15 +57,6 @@ describe('MediaConnection', () => {
   });
 
   describe('Constructor', () => {
-    it("should not call negotiator's startConnection method when created and originator", () => {
-      const mc = new MediaConnection('remoteId', {
-        stream: {},
-        originator: true,
-      });
-      assert(mc);
-      assert(startSpy.notCalled);
-    });
-
     it('should store any messages passed in when created', () => {
       const mc = new MediaConnection('remoteId', {
         stream: {},

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -57,17 +57,11 @@ describe('MediaConnection', () => {
   });
 
   describe('Constructor', () => {
-    it("should call negotiator's startConnection method when created and originator", () => {
+    it("should not call negotiator's startConnection method when created and originator", () => {
       const mc = new MediaConnection('remoteId', {
         stream: {},
         originator: true,
       });
-      assert(mc);
-      assert(startSpy.calledOnce);
-    });
-
-    it("should not call negotiator's startConnection method when created and not originator", () => {
-      const mc = new MediaConnection('remoteId', { stream: {} });
       assert(mc);
       assert(startSpy.notCalled);
     });
@@ -96,6 +90,26 @@ describe('MediaConnection', () => {
       assert.equal(mc.localStream, stream);
       assert.equal(mc.metadata, metadata);
       assert.equal(mc._options, options);
+    });
+  });
+
+  describe('startConnection', () => {
+    it("should call negotiator's startConnection method when created and originator", async () => {
+      const mc = new MediaConnection('remoteId', {
+        stream: {},
+        originator: true,
+      });
+      await mc.startConnection();
+
+      assert(mc);
+      assert(startSpy.calledOnce);
+    });
+    it("should not call negotiator's startConnection method when created and not originator", async () => {
+      const mc = new MediaConnection('remoteId', { stream: {} });
+      await mc.startConnection();
+
+      assert(mc);
+      assert(startSpy.notCalled);
     });
   });
 

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -42,6 +42,7 @@ describe('MeshRoom', () => {
 
     dcStub.returns({
       type: 'data',
+      startConnection: sinon.spy(),
       on: onSpy,
     });
 

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -32,6 +32,7 @@ describe('MeshRoom', () => {
 
     mcStub.returns({
       type: 'media',
+      startConnection: sinon.spy(),
       on: onSpy,
       close: closeSpy,
       answer: answerSpy,

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -806,7 +806,7 @@ describe('Negotiator', () => {
       describe('onnegotiationneeded', () => {
         describe('if originator', () => {
           beforeEach(() => {
-            negotiator._originator = true;
+            negotiator.originator = true;
           });
           it('should call _makeOfferSdp', () => {
             const makeOfferSdpSpy = sinon.spy(negotiator, '_makeOfferSdp');


### PR DESCRIPTION
#### Overview
- do nothing in constructor calls
  - just setup/parse options, or something
  - don't communicate inner/outer modules
  - now, we have to call `startConnection()` manually
- if merge this PR before merging #97 , #97 may not need to be merged
  - ensure await-ing `negotiator.startConnection()`, then `_handleQueuedMessages()` resolves this issue

#### TODO
- main
  - [x] DataConnection
  - [x] MediaConnection
- tests
  - [x] DataConnection
  - [x] MediaConnection
- [x] check `_handleQueuedMessages()` issue
  - maybe no problem, but really...?
- [x] think not need to await all async calls?
  - if needed, just await it
- [x] check test consistency
  - `negotiator.startConnection()` is not called in `new XxxConnection()` anymore
- [x] check `/examples`
- [ ] pick some lines to sort queued messages
  - just to be sure, if needed