### PR TITLE
Fixed skyway.js was broken when uploading to Github release

### DIFF
--- a/.circleci/deploy_master/create_release.sh
+++ b/.circleci/deploy_master/create_release.sh
@@ -44,5 +44,5 @@ url="https://uploads.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_R
 for path in dist/*; do
     filename=$(basename $path);
     echo "Uploading $filename to releases";
-    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/javascript" -d @"./dist/${filename}" "${url}?name=$filename"
+    curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/javascript" --data-binary @"./dist/${filename}" "${url}?name=$filename"
 done


### PR DESCRIPTION
When using `-d` option in curl, curl delete new line codes in that file.
So we should use `--data-binary` option for upload to github release.

https://qiita.com/aosho235/items/d89bb027db0c5662d8c5