### PR TITLE
Set sdpSemantics: 'plan-b' when creating PeerConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix bug about support for sdpSemantics options
+- Fix that SkyWay always uses 'plan-b' as SDP format
 
 ## [v1.1.19](https://github.com/skyway/skyway-js-sdk/releases/tag/v1.1.19) - 2018-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.1.20](https://github.com/skyway/skyway-js-sdk/releases/tag/v1.1.20) - 2019-**-**
+
+### Fixed
+
+- Fix bug about support for sdpSemantics options
+
 ## [v1.1.19](https://github.com/skyway/skyway-js-sdk/releases/tag/v1.1.19) - 2018-12-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyway-js",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyway-js",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "The official JavaScript SDK for SkyWay",
   "main": "dist/skyway.js",
   "module": "src/peer.js",

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -226,8 +226,9 @@ class Negotiator extends EventEmitter {
     this._isForceUseStreamMethods =
       browserInfo.name === 'chrome' && browserInfo.major <= 64;
 
-    // If client does NOT configure pcConfig.sdpSemantics, set 'plan-b'.
-    if (!pcConfig.sdpSemantics) {
+    // If client customizes pcConfig, set 'plan-b'.
+    // TODO: When JS-SDK supports for 'unified-plan', this process should be changed.
+    if (pcConfig) {
       pcConfig.sdpSemantics = 'plan-b';
     }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -204,7 +204,7 @@ class Negotiator extends EventEmitter {
    * @return {RTCPeerConnection} An instance of RTCPeerConnection.
    * @private
    */
-  _createPeerConnection(pcConfig) {
+  _createPeerConnection(pcConfig = {}) {
     logger.log('Creating RTCPeerConnection');
 
     const browserInfo = util.detectBrowser();
@@ -226,14 +226,8 @@ class Negotiator extends EventEmitter {
     this._isForceUseStreamMethods =
       browserInfo.name === 'chrome' && browserInfo.major <= 64;
 
-    // If client customizes pcConfig, set 'plan-b'.
-    // TODO: When JS-SDK supports for 'unified-plan', this process should be changed.
-    if (pcConfig) {
-      pcConfig.sdpSemantics = 'plan-b';
-    }
-
-    // Calling RTCPeerConnection with an empty object causes an error
-    // Either give it a proper pcConfig or undefined
+    // Force plan-b for SFU, until we finish unified-plan support.
+    pcConfig.sdpSemantics = 'plan-b';
     return new RTCPeerConnection(pcConfig);
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -226,6 +226,11 @@ class Negotiator extends EventEmitter {
     this._isForceUseStreamMethods =
       browserInfo.name === 'chrome' && browserInfo.major <= 64;
 
+    // If client does NOT configure pcConfig.sdpSemantics, set 'plan-b'.
+    if (!pcConfig.sdpSemantics) {
+      pcConfig.sdpSemantics = 'plan-b';
+    }
+
     // Calling RTCPeerConnection with an empty object causes an error
     // Either give it a proper pcConfig or undefined
     return new RTCPeerConnection(pcConfig);

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -67,7 +67,6 @@ const defaultConfig = {
     },
   ],
   iceTransportPolicy: 'all',
-  sdpSemantics: 'plan-b',
 };
 
 export default {

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -678,14 +678,34 @@ describe('Negotiator', () => {
   });
 
   describe('_createPeerConnection', () => {
+    let negotiator;
+    let pcConf;
+    beforeEach(() => {
+      negotiator = new Negotiator();
+    });
+
     it('should call RTCPeerConnection with pcConfig', () => {
       const pcStub = sinon.stub(window, 'RTCPeerConnection');
-      const negotiator = new Negotiator();
-      const pcConf = {};
+      pcConf = {};
       negotiator._createPeerConnection(pcConf);
 
       assert(pcStub.calledWith(pcConf));
       pcStub.restore();
+    });
+
+    it('should set "plan-b" with pcConfig', () => {
+      pcConf = { sdpSemantics: 'unified-plan' };
+      negotiator._createPeerConnection(pcConf);
+
+      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
+      assert.equal(pcConf.sdpSemantics, 'plan-b');
+    });
+
+    it('should set "plan-b" without pcConfig', () => {
+      negotiator._createPeerConnection();
+
+      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
+      assert.equal(pcConf.sdpSemantics, 'plan-b');
     });
   });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -702,8 +702,9 @@ describe('Negotiator', () => {
       assert.equal(pcConf.sdpSemantics, 'plan-b');
     });
 
-    it('should set "plan-b" without pcConfig', () => {
-      negotiator._createPeerConnection();
+    it('should set "plan-b" with empty pcConfig', () => {
+      pcConf = {};
+      negotiator._createPeerConnection(pcConf);
 
       // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
       assert.equal(pcConf.sdpSemantics, 'plan-b');

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -680,14 +680,13 @@ describe('Negotiator', () => {
 
   describe('_createPeerConnection', () => {
     let negotiator;
-    let pcConf;
     beforeEach(() => {
       negotiator = new Negotiator();
     });
 
     it('should call RTCPeerConnection with pcConfig', () => {
       const pcStub = sinon.stub(window, 'RTCPeerConnection');
-      pcConf = {};
+      const pcConf = {};
       negotiator._createPeerConnection(pcConf);
 
       assert(pcStub.calledWith(pcConf));
@@ -695,7 +694,7 @@ describe('Negotiator', () => {
     });
 
     it('should set "plan-b" with pcConfig', () => {
-      pcConf = { sdpSemantics: 'unified-plan' };
+      const pcConf = { sdpSemantics: 'unified-plan' };
       negotiator._createPeerConnection(pcConf);
 
       // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
@@ -703,7 +702,7 @@ describe('Negotiator', () => {
     });
 
     it('should set "plan-b" with empty pcConfig', () => {
-      pcConf = {};
+      const pcConf = {};
       negotiator._createPeerConnection(pcConf);
 
       // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -269,7 +269,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      negotiator._pc = negotiator._createPeerConnection();
+      negotiator._pc = negotiator._createPeerConnection({});
     });
 
     describe('rtpSenders are supported', () => {
@@ -454,7 +454,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      negotiator._pc = negotiator._createPeerConnection();
+      negotiator._pc = negotiator._createPeerConnection({});
     });
 
     describe('when offerSdp is empty', () => {
@@ -539,7 +539,7 @@ describe('Negotiator', () => {
     let negotiator;
     beforeEach(() => {
       negotiator = new Negotiator();
-      negotiator._pc = negotiator._createPeerConnection();
+      negotiator._pc = negotiator._createPeerConnection({});
     });
     describe('when _isExpectingAnswer is true', () => {
       beforeEach(() => {
@@ -629,6 +629,7 @@ describe('Negotiator', () => {
         type: 'data',
         originator: true,
         offer: {},
+        pcConfig: {},
       };
       negotiator.startConnection(options);
     });
@@ -669,7 +670,7 @@ describe('Negotiator', () => {
   describe('cleanup', () => {
     it('should close and remove PC upon cleanup()', () => {
       const negotiator = new Negotiator();
-      negotiator._pc = negotiator._createPeerConnection();
+      negotiator._pc = negotiator._createPeerConnection({});
 
       assert(negotiator._pc);
       negotiator.cleanup();
@@ -712,7 +713,7 @@ describe('Negotiator', () => {
   describe('_setupPCListeners', () => {
     it('should set up PeerConnection listeners', () => {
       const negotiator = new Negotiator();
-      const pc = (negotiator._pc = negotiator._createPeerConnection());
+      const pc = (negotiator._pc = negotiator._createPeerConnection({}));
 
       negotiator._setupPCListeners();
       assert.equal(typeof pc.ondatachannel, 'function');
@@ -729,7 +730,7 @@ describe('Negotiator', () => {
 
       beforeEach(() => {
         negotiator = new Negotiator();
-        pc = negotiator._pc = negotiator._createPeerConnection();
+        pc = negotiator._pc = negotiator._createPeerConnection({});
         negotiator._setupPCListeners();
       });
 
@@ -757,13 +758,9 @@ describe('Negotiator', () => {
         });
 
         it("should emit 'iceCandidatesComplete' when out of candidates", done => {
-          const ev = {};
-          negotiator.on(
-            Negotiator.EVENTS.iceCandidatesComplete.key,
-            description => {
-              assert(description instanceof RTCSessionDescription);
-              done();
-            }
+          const ev = { candidate: null };
+          negotiator.on(Negotiator.EVENTS.iceCandidatesComplete.key, () =>
+            done()
           );
 
           pc.onicecandidate(ev);
@@ -793,7 +790,7 @@ describe('Negotiator', () => {
             iceConnectionState: 'disconnected',
           });
           negotiator = new Negotiator();
-          pc = negotiator._pc = negotiator._createPeerConnection();
+          pc = negotiator._pc = negotiator._createPeerConnection({});
           negotiator._setupPCListeners();
         });
 
@@ -919,7 +916,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      pc = negotiator._pc = negotiator._createPeerConnection();
+      pc = negotiator._pc = negotiator._createPeerConnection({});
       negotiator._setupPCListeners();
 
       createOfferStub = sinon.stub(pc, 'createOffer');
@@ -974,7 +971,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      pc = negotiator._pc = negotiator._createPeerConnection();
+      pc = negotiator._pc = negotiator._createPeerConnection({});
       negotiator._setupPCListeners();
 
       createAnswerStub = sinon.stub(pc, 'createAnswer');
@@ -1050,7 +1047,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      pc = negotiator._pc = negotiator._createPeerConnection();
+      pc = negotiator._pc = negotiator._createPeerConnection({});
       negotiator._setupPCListeners();
 
       setLocalDescriptionStub = sinon.stub(pc, 'setLocalDescription');
@@ -1120,7 +1117,7 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       negotiator = new Negotiator();
-      pc = negotiator._pc = negotiator._createPeerConnection();
+      pc = negotiator._pc = negotiator._createPeerConnection({});
       negotiator._setupPCListeners();
 
       setRemoteDescriptionStub = sinon.stub(pc, 'setRemoteDescription');


### PR DESCRIPTION
This is bug fix about support for Unified-Plan.
[Problem]
If user configuires `config` when `new Peer()`, `defaultConfig` is ignored.
`defaultConfig.sdpSemantics: "plan-b"`  is ignored if user does not set the property `config.sdpSemantics`. This causes bug.

[Solution]
Set `pcConfig.sdpSemantics: "plan-b"` if the property `config` is customized by user in `new Peer()`.