### PR TITLE
Use unified-plan and remove legacy APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "js-binarypack": "0.0.9",
     "object-sizeof": "^1.0.10",
     "query-string": "^5.0.0",
-    "sdp-interop": "^0.1.11",
     "sdp-transform": "^2.3.0",
     "socket.io-client": "^2.0.3"
   }

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -175,14 +175,12 @@ class Connection extends EventEmitter {
    * @private
    */
   _setupNegotiatorMessageHandlers() {
-    const browserInfo = util.detectBrowser();
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
       const connectionAnswer = {
         answer: answer,
         dst: this.remoteId,
         connectionId: this.id,
         connectionType: this.type,
-        browser: browserInfo,
       };
       this.emit(Connection.EVENTS.answer.key, connectionAnswer);
     });
@@ -194,7 +192,6 @@ class Connection extends EventEmitter {
         connectionId: this.id,
         connectionType: this.type,
         metadata: this.metadata,
-        browser: browserInfo,
       };
       if (this.serialization) {
         connectionOffer.serialization = this.serialization;

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -78,7 +78,6 @@ class Connection extends EventEmitter {
   async handleAnswer(answerMessage) {
     if (this._pcAvailable) {
       await this._negotiator.handleAnswer(answerMessage.answer);
-      this._negotiator.setRemoteBrowser(answerMessage.browser);
       this.open = true;
       this._handleQueuedMessages();
     } else {

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -4,7 +4,7 @@ import Negotiator from './negotiator';
 import Connection from './connection';
 import logger from '../shared/logger';
 
-const MCEvents = new Enum(['stream', 'removeStream']);
+const MCEvents = new Enum(['stream']);
 
 MCEvents.extend(Connection.EVENTS.enums);
 
@@ -144,16 +144,6 @@ class MediaConnection extends Connection {
 
       this.emit(MediaConnection.EVENTS.stream.key, remoteStream);
     });
-
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, remoteStream => {
-      logger.log('Stream removed', remoteStream);
-
-      // Don't unset if a new stream has already replaced the old one
-      if (this.remoteStream === remoteStream) {
-        this.remoteStream = null;
-      }
-      this.emit(MediaConnection.EVENTS.removeStream.key, remoteStream);
-    });
   }
 
   /**
@@ -168,13 +158,6 @@ class MediaConnection extends Connection {
    * MediaStream received from peer.
    *
    * @event MediaConnection#stream
-   * @type {MediaStream}
-   */
-
-  /**
-   * MediaStream from peer was removed.
-   *
-   * @event MediaConnection#removeStream
    * @type {MediaStream}
    */
 }

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -109,7 +109,6 @@ class MediaConnection extends Connection {
       videoReceiveEnabled: options.videoReceiveEnabled,
       audioReceiveEnabled: options.audioReceiveEnabled,
     });
-    this._negotiator.setRemoteBrowser(this._options.payload.browser);
     this._pcAvailable = true;
 
     this._handleQueuedMessages();

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -388,10 +388,6 @@ class MeshRoom extends Room {
         remoteStream.peerId = connection.remoteId;
         this.emit(MeshRoom.EVENTS.stream.key, remoteStream);
       });
-
-      connection.on(MediaConnection.EVENTS.removeStream.key, remoteStream => {
-        this.emit(MeshRoom.EVENTS.removeStream.key, remoteStream);
-      });
     }
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -63,7 +63,6 @@ class Negotiator extends EventEmitter {
     this._videoCodec = options.videoCodec;
     this._type = options.type;
     this._recvonlyState = this._getReceiveOnlyState(options);
-    this._remoteBrowser = {};
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -87,10 +86,6 @@ class Negotiator extends EventEmitter {
     } else {
       await this.handleOffer(options.offer);
     }
-  }
-
-  setRemoteBrowser(browser) {
-    this._remoteBrowser = browser;
   }
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -3,7 +3,6 @@ import Enum from 'enum';
 
 import sdpUtil from '../shared/sdpUtil';
 import logger from '../shared/logger';
-import util from '../shared/util';
 
 const NegotiatorEvents = new Enum([
   'addStream',
@@ -70,13 +69,7 @@ class Negotiator extends EventEmitter {
 
     if (this._type === 'media') {
       if (options.stream) {
-        if (this._isAddTrackAvailable && !this._isForceUseStreamMethods) {
-          options.stream.getTracks().forEach(track => {
-            this._pc.addTrack(track, options.stream);
-          });
-        } else {
-          this._pc.addStream(options.stream);
-        }
+        this._pc.addStream(options.stream);
       } else if (this.originator) {
         // This means the peer wants to create offer SDP with `recvonly`
         const offer = await this._makeOfferSdp();
@@ -115,13 +108,7 @@ class Negotiator extends EventEmitter {
 
     // Replace the tracks in the rtpSenders if possible.
     // This doesn't require renegotiation.
-    if (this._isRtpSenderAvailable && !this._isForceUseStreamMethods) {
-      this._replacePerTrack(newStream);
-    } else if (!this._replaceStreamCalled) {
-      // _replacePerStream is used for Chrome 64 and below. All other browsers should have track methods implemented.
-      // We can delete _replacePerStream after Chrome 64 is no longer supported.
-      this._replacePerStream(newStream);
-    }
+    this._replacePerTrack(newStream);
   }
 
   /**
@@ -207,27 +194,8 @@ class Negotiator extends EventEmitter {
   _createPeerConnection(pcConfig = {}) {
     logger.log('Creating RTCPeerConnection');
 
-    const browserInfo = util.detectBrowser();
-
-    this._isAddTrackAvailable =
-      typeof RTCPeerConnection.prototype.addTrack === 'function';
-    this._isOnTrackAvailable = 'ontrack' in RTCPeerConnection.prototype;
-    this._isRtpSenderAvailable =
-      typeof RTCPeerConnection.prototype.getSenders === 'function';
-
-    // If browser is Chrome and over 69, it has addTransceiver but does not work without unified-plan option.
-    // SkyWay has not supported unified-plan.
-    this._isAddTransceiverAvailable =
-      typeof RTCPeerConnection.prototype.addTransceiver === 'function' &&
-      browserInfo.name !== 'chrome';
-
-    // If browser is Chrome 64, we use addStream/replaceStream instead of addTrack/replaceTrack.
-    // Because Chrome can't call properly to Firefox using track methods.
-    this._isForceUseStreamMethods =
-      browserInfo.name === 'chrome' && browserInfo.major <= 64;
-
-    // Force plan-b for SFU, until we finish unified-plan support.
-    pcConfig.sdpSemantics = 'plan-b';
+    // Force unified-plan as our default semantics.
+    pcConfig.sdpSemantics = 'unified-plan';
     return new RTCPeerConnection(pcConfig);
   }
 
@@ -237,20 +205,12 @@ class Negotiator extends EventEmitter {
    */
   _setupPCListeners() {
     const pc = this._pc;
-    if (this._isOnTrackAvailable && !this._isForceUseStreamMethods) {
-      pc.ontrack = evt => {
-        logger.log('Received remote media stream');
-        evt.streams.forEach(stream => {
-          this.emit(Negotiator.EVENTS.addStream.key, stream);
-        });
-      };
-    } else {
-      pc.onaddstream = evt => {
-        logger.log('Received remote media stream');
-        const stream = evt.stream;
+    pc.ontrack = evt => {
+      logger.log('Received remote media stream');
+      evt.streams.forEach(stream => {
         this.emit(Negotiator.EVENTS.addStream.key, stream);
-      };
-    }
+      });
+    };
 
     pc.ondatachannel = evt => {
       logger.log('Received data channel');
@@ -356,21 +316,11 @@ class Negotiator extends EventEmitter {
         offer = await this._pc.createOffer();
         // MediaConnection
       } else {
-        if (this._isAddTransceiverAvailable) {
-          this._recvonlyState.audio &&
-            this._pc.addTransceiver('audio', { direction: 'recvonly' });
-          this._recvonlyState.video &&
-            this._pc.addTransceiver('video', { direction: 'recvonly' });
-          offer = await this._pc.createOffer();
-        } else {
-          const offerOptions = {};
-          // the offerToReceiveXXX options are defined in the specs as boolean but `undefined` acts differently from false
-          this._recvonlyState.audio &&
-            (offerOptions.offerToReceiveAudio = true);
-          this._recvonlyState.video &&
-            (offerOptions.offerToReceiveVideo = true);
-          offer = await this._pc.createOffer(offerOptions);
-        }
+        this._recvonlyState.audio &&
+          this._pc.addTransceiver('audio', { direction: 'recvonly' });
+        this._recvonlyState.video &&
+          this._pc.addTransceiver('video', { direction: 'recvonly' });
+        offer = await this._pc.createOffer();
       }
     } catch (err) {
       err.type = 'webrtc';
@@ -596,65 +546,6 @@ class Negotiator extends EventEmitter {
         return;
       }
       sender.replaceTrack(track);
-    }
-  }
-
-  /**
-   * Replace the stream being sent with a new one.
-   * Video and audio are replaced per stream by using `xxxStream` methods.
-   * This method is used in some browsers which don't implement `xxxTrack` methods.
-   * @param {MediaStream} newStream - The stream to replace the old stream with.
-   * @private
-   */
-  _replacePerStream(newStream) {
-    const localStreams = this._pc.getLocalStreams();
-
-    const origOnNegotiationNeeded = this._pc.onnegotiationneeded;
-    this._pc.onnegotiationneeded = () => {};
-
-    // We assume that there is at most 1 stream in localStreams
-    if (localStreams.length > 0) {
-      this._pc.removeStream(localStreams[0]);
-    }
-
-    // HACK: For some reason FF59 doesn't work when Chrome 64 renegotiates after updating the stream.
-    // However, simply updating the localDescription updates the remote stream if the other browser is firefox 59+.
-    // Chrome 64 probably uses replaceTrack-like functions internally.
-    const isRemoteBrowserNeedRenegotiation =
-      this._remoteBrowser &&
-      this._remoteBrowser.name === 'firefox' &&
-      this._remoteBrowser.major >= 59;
-    if (isRemoteBrowserNeedRenegotiation) {
-      this._pc.addStream(newStream);
-
-      // use setTimeout to trigger (and do nothing) on add/removeStream.
-      setTimeout(async () => {
-        // update the localDescription with the new stream information (after getting to the right state)
-        try {
-          if (this.originator) {
-            const offer = await this._makeOfferSdp();
-            await this._pc.setLocalDescription(offer);
-            await this._pc.setRemoteDescription(this._pc.remoteDescription);
-          } else {
-            await this._pc.setRemoteDescription(this._pc.remoteDescription);
-            const answer = await this._pc.createAnswer();
-            await this._pc.setLocalDescription(answer);
-          }
-        } catch (err) {
-          logger.error(err);
-        }
-        this._pc.onnegotiationneeded = origOnNegotiationNeeded;
-      });
-    } else {
-      // this is the normal flow where we renegotiate.
-      this._replaceStreamCalled = true;
-
-      // use setTimeout to trigger (and do nothing) on removeStream.
-      setTimeout(() => {
-        // onnegotiationneeded will be triggered by addStream.
-        this._pc.addStream(newStream);
-        this._pc.onnegotiationneeded = origOnNegotiationNeeded;
-      });
     }
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -6,7 +6,6 @@ import logger from '../shared/logger';
 
 const NegotiatorEvents = new Enum([
   'addStream',
-  'removeStream',
   'dcCreated',
   'offerCreated',
   'answerCreated',
@@ -275,11 +274,6 @@ class Negotiator extends EventEmitter {
           this.emit(Negotiator.EVENTS.negotiationNeeded.key);
         }
       }
-    };
-
-    pc.onremovestream = evt => {
-      logger.log('`removestream` triggered');
-      this.emit(Negotiator.EVENTS.removeStream.key, evt.stream);
     };
 
     pc.onsignalingstatechange = () => {

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -30,7 +30,6 @@ class Negotiator extends EventEmitter {
     super();
     this._offerQueue = [];
     this._isExpectingAnswer = false;
-    this._replaceStreamCalled = false;
     this._isNegotiationAllowed = true;
     this.hasRemoteDescription = false;
   }
@@ -274,11 +273,7 @@ class Negotiator extends EventEmitter {
           const offer = await this._makeOfferSdp();
           this._setLocalDescription(offer);
           this.emit(Negotiator.EVENTS.negotiationNeeded.key);
-        } else if (this._replaceStreamCalled) {
-          this.handleOffer();
         }
-
-        this._replaceStreamCalled = false;
       }
     };
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -30,7 +30,9 @@ class Negotiator extends EventEmitter {
     super();
     this._offerQueue = [];
     this._isExpectingAnswer = false;
+    this._replaceStreamCalled = false;
     this._isNegotiationAllowed = true;
+    this.hasRemoteDescription = false;
   }
 
   /**
@@ -272,7 +274,11 @@ class Negotiator extends EventEmitter {
           const offer = await this._makeOfferSdp();
           this._setLocalDescription(offer);
           this.emit(Negotiator.EVENTS.negotiationNeeded.key);
+        } else if (this._replaceStreamCalled) {
+          this.handleOffer();
         }
+
+        this._replaceStreamCalled = false;
       }
     };
 
@@ -431,6 +437,7 @@ class Negotiator extends EventEmitter {
 
     try {
       await this._pc.setRemoteDescription(new RTCSessionDescription(sdp));
+      this.hasRemoteDescription = true;
     } catch (err) {
       err.type = 'webrtc';
       logger.error(err);

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -69,7 +69,9 @@ class Negotiator extends EventEmitter {
 
     if (this._type === 'media') {
       if (options.stream) {
-        this._pc.addStream(options.stream);
+        options.stream.getTracks().forEach(track => {
+          this._pc.addTrack(track, options.stream);
+        });
       } else if (this.originator) {
         // This means the peer wants to create offer SDP with `recvonly`
         const offer = await this._makeOfferSdp();

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -30,9 +30,7 @@ class Negotiator extends EventEmitter {
     super();
     this._offerQueue = [];
     this._isExpectingAnswer = false;
-    this._replaceStreamCalled = false;
     this._isNegotiationAllowed = true;
-    this.hasRemoteDescription = false;
   }
 
   /**
@@ -274,11 +272,7 @@ class Negotiator extends EventEmitter {
           const offer = await this._makeOfferSdp();
           this._setLocalDescription(offer);
           this.emit(Negotiator.EVENTS.negotiationNeeded.key);
-        } else if (this._replaceStreamCalled) {
-          this.handleOffer();
         }
-
-        this._replaceStreamCalled = false;
       }
     };
 
@@ -437,7 +431,6 @@ class Negotiator extends EventEmitter {
 
     try {
       await this._pc.setRemoteDescription(new RTCSessionDescription(sdp));
-      this.hasRemoteDescription = true;
     } catch (err) {
       err.type = 'webrtc';
       logger.error(err);

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -3,7 +3,6 @@ import Enum from 'enum';
 
 const Events = [
   'stream',
-  'removeStream',
   'open',
   'close',
   'peerJoin',

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -3,6 +3,7 @@ import Enum from 'enum';
 import Room from './room';
 import Negotiator from './negotiator';
 import logger from '../shared/logger';
+import sdpUtil from '../shared/sdpUtil';
 
 const MessageEvents = ['offerRequest', 'candidate'];
 
@@ -124,6 +125,8 @@ class SFURoom extends Room {
     });
 
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
+      // Currenly, our signaling server does not handle our original sdp as unified-plan.
+      answer.sdp = sdpUtil.pretendUnifiedPlan(answer.sdp);
       const answerMessage = {
         roomName: this.name,
         answer: answer,

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -127,8 +127,6 @@ class SFURoom extends Room {
       const answerMessage = {
         roomName: this.name,
         answer: answer,
-        // Notify our server that JS-SDK supports unified-plan.
-        sdpSemantics: 'unified-plan',
       };
       this.emit(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage);
     });

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -126,14 +126,6 @@ class SFURoom extends Room {
       }
     });
 
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-      delete this.remoteStreams[stream.id];
-      delete this._msidMap[stream.id];
-      delete this._unknownStreams[stream.id];
-
-      this.emit(SFURoom.EVENTS.removeStream.key, stream);
-    });
-
     this._negotiator.on(Negotiator.EVENTS.negotiationNeeded.key, () => {
       // Renegotiate by requesting an offer then sending an answer when one is created.
       const offerRequestMessage = {
@@ -208,6 +200,8 @@ class SFURoom extends Room {
     for (const msid in this.remoteStreams) {
       if (this.remoteStreams[msid].peerId === src) {
         delete this.remoteStreams[msid];
+        delete this._msidMap[msid];
+        delete this._unknownStreams[msid];
       }
     }
 

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -3,8 +3,6 @@ import Enum from 'enum';
 import Room from './room';
 import Negotiator from './negotiator';
 import logger from '../shared/logger';
-import sdpUtil from '../shared/sdpUtil';
-import util from '../shared/util';
 
 const MessageEvents = ['offerRequest', 'candidate'];
 
@@ -67,16 +65,7 @@ class SFURoom extends Room {
    * @param {object} offerMessage - Message object containing Offer SDP.
    * @param {object} offerMessage.offer - Object containing Offer SDP text.
    */
-  handleOffer(offerMessage) {
-    let offer = offerMessage.offer;
-
-    // Chrome and Safari can't handle unified plan messages so convert it to Plan B
-    // We don't need to convert the answer back to Unified Plan because the server can handle Plan B
-    const browserInfo = util.detectBrowser();
-    if (browserInfo.name !== 'firefox') {
-      offer = sdpUtil.unifiedToPlanB(offer);
-    }
-
+  handleOffer({ offer }) {
     // Handle SFU Offer and send Answer to Server
     if (this._connectionStarted) {
       this._negotiator.handleOffer(offer);
@@ -138,6 +127,8 @@ class SFURoom extends Room {
       const answerMessage = {
         roomName: this.name,
         answer: answer,
+        // Notify our server that JS-SDK supports unified-plan.
+        sdpSemantics: 'unified-plan',
       };
       this.emit(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage);
     });

--- a/src/shared/sdpUtil.js
+++ b/src/shared/sdpUtil.js
@@ -49,6 +49,34 @@ class SdpUtil {
   }
 
   /**
+   * Our signaling server determines client's SDP semantics
+   * by checking answer SDP includes `a=msid-semantic:WMS *` or NOT.
+   *
+   * Currenly, Firefox prints exact string,
+   * but Chrome does not. even using `unified-plan`.
+   * Therefore Chrome needs to pretend Firefox to join SFU rooms.
+   *
+   * At a glance, using `sdp-transform` is better choice to munge SDP,
+   * but if you do so, it prints `a=msid-semantic: WMS *`.
+   * The problem is the space before the word `WMS`,
+   * our signaling server can not handle this as `unified-plan` SDP...
+   *
+   * @param {string} sdp - A SDP.
+   * @return {string} A SDP which has `a=msid-semantic:WMS *`.
+   */
+  pretendUnifiedPlan(sdp) {
+    const delimiter = '\r\n';
+    return sdp
+      .split(delimiter)
+      .map(line => {
+        return line.startsWith('a=msid-semantic')
+          ? 'a=msid-semantic:WMS *'
+          : line;
+      })
+      .join(delimiter);
+  }
+
+  /**
    * Remove codecs except the codec passed as argument and return the SDP
    *
    * @param {string} sdp - A SDP.

--- a/src/shared/sdpUtil.js
+++ b/src/shared/sdpUtil.js
@@ -1,42 +1,9 @@
 import sdpTransform from 'sdp-transform';
-import { Interop } from 'sdp-interop';
 
 /**
  * Class that contains utility functions for SDP munging.
  */
 class SdpUtil {
-  /**
-   * Convert unified plan SDP to Plan B SDP
-   * @param {RTCSessionDescriptionInit} offer unified plan SDP
-   * @return {RTCSessionDescription} Plan B SDP
-   */
-  unifiedToPlanB(offer) {
-    const interop = new Interop();
-    const oldSdp = interop.toPlanB(offer).sdp;
-
-    // use a set to avoid duplicates
-    const msids = new Set();
-    // extract msids from the offer sdp
-    const msidRegexp = /a=ssrc:\d+ msid:(\w+)/g;
-    let matches;
-    // loop while matches is truthy
-    // double parentheses for explicit conditional assignment (lint)
-    while ((matches = msidRegexp.exec(oldSdp))) {
-      msids.add(matches[1]);
-    }
-
-    // replace msid-semantic line with planB version
-    const newSdp = oldSdp.replace(
-      'a=msid-semantic:WMS *',
-      `a=msid-semantic:WMS ${Array.from(msids).join(' ')}`
-    );
-
-    return new RTCSessionDescription({
-      type: 'offer',
-      sdp: newSdp,
-    });
-  }
-
   /**
    * Add b=AS to m=video section and return the SDP.
    * @param {string} sdp - A SDP.

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -38,7 +38,6 @@ describe('MediaConnection', () => {
       handleAnswer: answerSpy,
       handleCandidate: candidateSpy,
       replaceStream: replaceSpy,
-      setRemoteBrowser: sinon.spy(),
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;
@@ -181,45 +180,6 @@ describe('MediaConnection', () => {
       assert(spy.calledOnce);
       assert(
         spy.calledWith(MediaConnection.EVENTS.stream.key, 'fakeStream') === true
-      );
-
-      spy.restore();
-    });
-
-    it("should set remoteStream to null on 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = remoteStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert.equal(mc.remoteStream, null);
-    });
-
-    it("should not change remoteStream on 'removeStream' being emitted if remoteStream is different", () => {
-      const origStream = {};
-      const removeStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = origStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, removeStream);
-
-      assert.equal(mc.remoteStream, origStream);
-    });
-
-    it("should emit a 'removeStream' event upon 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-
-      const spy = sinon.spy(mc, 'emit');
-
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert(mc);
-      assert(spy.calledOnce);
-      assert(
-        spy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          remoteStream
-        ) === true
       );
 
       spy.restore();

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -557,17 +557,11 @@ describe('MeshRoom', () => {
       );
     });
 
-    it('should handle stream and removeStream events if connection is a MediaConnection', () => {
+    it('should handle stream event if connection is a MediaConnection', () => {
       meshRoom._setupMessageHandlers({ on: onSpy, type: 'media' });
 
       assert(
         onSpy.calledWith(MediaConnection.EVENTS.stream.key, sinon.match.func)
-      );
-      assert(
-        onSpy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          sinon.match.func
-        )
       );
     });
 
@@ -655,20 +649,6 @@ describe('MeshRoom', () => {
           });
 
           mc.emit(MediaConnection.EVENTS.stream.key, stream);
-        });
-      });
-
-      describe('removeStream', () => {
-        it('should emit stream', done => {
-          const stream = {};
-
-          meshRoom.on(MeshRoom.EVENTS.removeStream.key, emittedStream => {
-            assert.equal(emittedStream, stream);
-
-            done();
-          });
-
-          mc.emit(MediaConnection.EVENTS.removeStream.key, stream);
         });
       });
     });

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -663,7 +663,7 @@ describe('Negotiator', () => {
       assert.equal(pcConf.sdpSemantics, 'unified-plan');
     });
 
-    it('should set "plan-b" with empty pcConfig', () => {
+    it('should set "unified-plan" with empty pcConfig', () => {
       const pcConf = {};
       negotiator._createPeerConnection(pcConf);
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -17,7 +17,7 @@ describe('Negotiator', () => {
   describe('startConnection', () => {
     let newPcStub;
     let pcStub;
-    let addStreamSpy;
+    let addTrackSpy;
     let createDCSpy;
     let negotiator;
     let handleOfferSpy;
@@ -26,10 +26,10 @@ describe('Negotiator', () => {
 
     beforeEach(() => {
       newPcStub = sinon.stub();
-      addStreamSpy = sinon.spy();
+      addTrackSpy = sinon.spy();
       createDCSpy = sinon.spy();
       pcStub = {
-        addStream: addStreamSpy,
+        addTrack: addTrackSpy,
         createDataChannel: createDCSpy,
       };
       newPcStub.returns(pcStub);
@@ -44,7 +44,7 @@ describe('Negotiator', () => {
 
     afterEach(() => {
       newPcStub.reset();
-      addStreamSpy.resetHistory();
+      addTrackSpy.resetHistory();
       createDCSpy.resetHistory();
       handleOfferSpy.resetHistory();
       setRemoteDescStub.restore();
@@ -65,20 +65,23 @@ describe('Negotiator', () => {
 
     describe("when type is 'media'", () => {
       describe('when originator is true', () => {
-        it('should call pc.addStream when stream exists', () => {
+        it('should call pc.addTrack when stream exists', () => {
+          const dummyMediaStream = new MediaStream();
+          sinon.stub(dummyMediaStream, 'getTracks').returns([{}]);
+
           const options = {
             type: 'media',
-            stream: {},
+            stream: dummyMediaStream,
             originator: true,
             pcConfig: {},
           };
 
-          assert.equal(addStreamSpy.callCount, 0);
+          assert.equal(addTrackSpy.callCount, 0);
           assert.equal(handleOfferSpy.callCount, 0);
 
           negotiator.startConnection(options);
 
-          assert.equal(addStreamSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 1);
           assert.equal(handleOfferSpy.callCount, 0);
         });
 
@@ -100,41 +103,47 @@ describe('Negotiator', () => {
       });
 
       describe('when originator is false', () => {
-        it('should call pc.addStream and handleOffer', () => {
+        it('should call pc.addTrack and handleOffer', () => {
+          const dummyMediaStream = new MediaStream();
+          sinon.stub(dummyMediaStream, 'getTracks').returns([{}]);
+
           const options = {
             type: 'media',
-            stream: {},
+            stream: dummyMediaStream,
             originator: false,
             pcConfig: {},
             offer: {},
           };
 
-          assert.equal(addStreamSpy.callCount, 0);
+          assert.equal(addTrackSpy.callCount, 0);
           assert.equal(handleOfferSpy.callCount, 0);
 
           negotiator.startConnection(options);
 
-          assert.equal(addStreamSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 1);
           assert.equal(handleOfferSpy.callCount, 1);
           assert(handleOfferSpy.calledWith(options.offer));
         });
       });
 
       describe('when originator is undefined', () => {
-        it('should call pc.addStream and handleOffer', () => {
+        it('should call pc.addTrack and handleOffer', () => {
+          const dummyMediaStream = new MediaStream();
+          sinon.stub(dummyMediaStream, 'getTracks').returns([{}]);
+
           const options = {
             type: 'media',
-            stream: {},
+            stream: dummyMediaStream,
             pcConfig: {},
             offer: {},
           };
 
-          assert.equal(addStreamSpy.callCount, 0);
+          assert.equal(addTrackSpy.callCount, 0);
           assert.equal(handleOfferSpy.callCount, 0);
 
           negotiator.startConnection(options);
 
-          assert.equal(addStreamSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 1);
           assert.equal(handleOfferSpy.callCount, 1);
           assert(handleOfferSpy.calledWith(options.offer));
         });
@@ -207,20 +216,20 @@ describe('Negotiator', () => {
 
     describe('when type is undefined', () => {
       describe('when originator is true', () => {
-        it("shouldn't call createDataConnection or addStream", () => {
+        it("shouldn't call createDataConnection or addTrack", () => {
           const options = {
             originator: true,
             pcConfig: {},
           };
 
           assert.equal(createDCSpy.callCount, 0);
-          assert.equal(addStreamSpy.callCount, 0);
+          assert.equal(addTrackSpy.callCount, 0);
           assert.equal(handleOfferSpy.callCount, 0);
 
           negotiator.startConnection(options);
 
           assert.equal(createDCSpy.callCount, 0);
-          assert.equal(addStreamSpy.callCount, 0);
+          assert.equal(addTrackSpy.callCount, 0);
           assert.equal(handleOfferSpy.callCount, 0);
         });
       });
@@ -267,184 +276,138 @@ describe('Negotiator', () => {
   describe('replaceStream', () => {
     let negotiator;
 
+    let addTrackStub;
+    let getSendersStub;
+    let removeTrackStub;
+    let getAudioTracksStub;
+    let getVideoTracksStub;
+    let negotiationNeededStub;
+
+    // These values are dummy for assert to distinguish audio and video in tests.
+    const videoTrack = {
+      video: 'video',
+    };
+    const audioTrack = {
+      audio: 'audio',
+    };
+    const anotherVideoTrack = {
+      id: 1000,
+      video: 'video',
+    };
+    const anotherAudioTrack = {
+      id: 1001,
+      video: 'audio',
+    };
+
+    let audioSender;
+    let videoSender;
+    let newStream;
+
     beforeEach(() => {
       negotiator = new Negotiator();
       negotiator._pc = negotiator._createPeerConnection({});
+      // We stub everything directly as there is no guarantee that the browser will support them.
+      addTrackStub = sinon.stub();
+      getSendersStub = sinon.stub();
+      removeTrackStub = sinon.stub();
+      negotiationNeededStub = sinon.spy();
+      negotiator._pc.addTrack = addTrackStub;
+      negotiator._pc.getSenders = getSendersStub;
+      negotiator._pc.removeTrack = removeTrackStub;
+      negotiator._pc.onnegotiationneeded = negotiationNeededStub;
+      negotiator._isRtpSenderAvailable = true;
+      negotiator._isForceUseStreamMethods = false;
+
+      audioSender = {
+        track: {
+          kind: 'audio',
+        },
+        replaceTrack: sinon.stub(),
+      };
+      videoSender = {
+        track: {
+          kind: 'video',
+        },
+        replaceTrack: sinon.stub(),
+      };
+      getSendersStub.returns([audioSender, videoSender]);
+
+      getVideoTracksStub = sinon.stub();
+      getAudioTracksStub = sinon.stub();
+
+      newStream = {
+        getVideoTracks: getVideoTracksStub,
+        getAudioTracks: getAudioTracksStub,
+      };
     });
 
-    describe('rtpSenders are supported', () => {
-      let addTrackStub;
-      let getSendersStub;
-      let removeTrackStub;
-      let getAudioTracksStub;
-      let getVideoTracksStub;
-      let negotiationNeededStub;
-
-      // These values are dummy for assert to distinguish audio and video in tests.
-      const videoTrack = {
-        video: 'video',
-      };
-      const audioTrack = {
-        audio: 'audio',
-      };
-      const anotherVideoTrack = {
-        id: 1000,
-        video: 'video',
-      };
-      const anotherAudioTrack = {
-        id: 1001,
-        video: 'audio',
-      };
-
-      let audioSender;
-      let videoSender;
-      let newStream;
-
+    describe('new stream has same number of tracks as current stream', () => {
       beforeEach(() => {
-        // We stub everything directly as there is no guarantee that the browser will support them.
-        addTrackStub = sinon.stub();
-        getSendersStub = sinon.stub();
-        removeTrackStub = sinon.stub();
-        negotiationNeededStub = sinon.spy();
-        negotiator._pc.addTrack = addTrackStub;
-        negotiator._pc.getSenders = getSendersStub;
-        negotiator._pc.removeTrack = removeTrackStub;
-        negotiator._pc.onnegotiationneeded = negotiationNeededStub;
-        negotiator._isRtpSenderAvailable = true;
-        negotiator._isForceUseStreamMethods = false;
-
-        audioSender = {
-          track: {
-            kind: 'audio',
-          },
-          replaceTrack: sinon.stub(),
-        };
-        videoSender = {
-          track: {
-            kind: 'video',
-          },
-          replaceTrack: sinon.stub(),
-        };
-        getSendersStub.returns([audioSender, videoSender]);
-
-        getVideoTracksStub = sinon.stub();
-        getAudioTracksStub = sinon.stub();
-
-        newStream = {
-          getVideoTracks: getVideoTracksStub,
-          getAudioTracks: getAudioTracksStub,
-        };
+        getVideoTracksStub.returns([videoTrack]);
+        getAudioTracksStub.returns([audioTrack]);
       });
 
-      describe('new stream has same number of tracks as current stream', () => {
-        beforeEach(() => {
-          getVideoTracksStub.returns([videoTrack]);
-          getAudioTracksStub.returns([audioTrack]);
-        });
+      it('should call replaceTrack for each sender if tracks have different id', () => {
+        getVideoTracksStub.returns([anotherVideoTrack]);
+        getAudioTracksStub.returns([anotherAudioTrack]);
 
-        it('should call replaceTrack for each sender if tracks have different id', () => {
-          getVideoTracksStub.returns([anotherVideoTrack]);
-          getAudioTracksStub.returns([anotherAudioTrack]);
-
-          negotiator.replaceStream(newStream);
-
-          assert.equal(audioSender.replaceTrack.callCount, 1);
-          assert(audioSender.replaceTrack.calledWith(anotherAudioTrack));
-
-          assert.equal(videoSender.replaceTrack.callCount, 1);
-          assert(videoSender.replaceTrack.calledWith(anotherVideoTrack));
-        });
-
-        it('should call replaceTrack for each sender if tracks have same id', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(audioSender.replaceTrack.callCount, 0);
-
-          assert.equal(videoSender.replaceTrack.callCount, 0);
-        });
-      });
-
-      describe('new stream has fewer number of tracks', () => {
-        beforeEach(() => {
-          getVideoTracksStub.returns([]);
-          getAudioTracksStub.returns([]);
-        });
-
-        it('should call removeTrack for each sender', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(removeTrackStub.callCount, 2);
-          assert(removeTrackStub.calledWith(audioSender));
-          assert(removeTrackStub.calledWith(videoSender));
-        });
-      });
-
-      describe('new stream has larger number of tracks', () => {
-        beforeEach(() => {
-          getSendersStub.returns([audioSender]);
-
-          getVideoTracksStub.returns([videoTrack]);
-          getAudioTracksStub.returns([audioTrack]);
-        });
-
-        it('should not call replaceTrack for audio sender', () => {
-          negotiator.replaceStream(newStream);
-
-          assert.equal(audioSender.replaceTrack.callCount, 0);
-        });
-
-        it('should not call addTrack for audio sender', () => {
-          negotiator.replaceStream(newStream);
-
-          assert(!addTrackStub.calledWith(audioTrack));
-        });
-
-        it('should call addTrack for video sender', () => {
-          negotiator.replaceStream(newStream);
-
-          assert(addTrackStub.calledWith(videoTrack));
-        });
-      });
-    });
-
-    describe("rtpSenders aren't supported", () => {
-      const remoteStream = {};
-      const newStream = {};
-
-      let removeStreamSpy;
-      let addStreamSpy;
-
-      beforeEach(() => {
-        // Stub directly so tests run after remove/addStream are removed.
-        removeStreamSpy = sinon.stub();
-        addStreamSpy = sinon.stub();
-        negotiator._pc.removeStream = removeStreamSpy;
-        negotiator._pc.addStream = addStreamSpy;
-        negotiator._isRtpSenderAvailable = false;
-
-        const getLocalStreamsStub = sinon.stub(
-          negotiator._pc,
-          'getLocalStreams'
-        );
-        getLocalStreamsStub.returns([remoteStream]);
-
-        // disable getSenders if available
-        negotiator._pc.getSenders = null;
-      });
-
-      it('should call removeStream then addStream', done => {
         negotiator.replaceStream(newStream);
 
-        // Use timeout as it runs asynchronously
-        setTimeout(() => {
-          assert.equal(removeStreamSpy.callCount, 1);
-          assert(removeStreamSpy.calledWith(remoteStream));
+        assert.equal(audioSender.replaceTrack.callCount, 1);
+        assert(audioSender.replaceTrack.calledWith(anotherAudioTrack));
 
-          assert.equal(addStreamSpy.callCount, 1);
-          assert(addStreamSpy.calledWith(newStream));
+        assert.equal(videoSender.replaceTrack.callCount, 1);
+        assert(videoSender.replaceTrack.calledWith(anotherVideoTrack));
+      });
 
-          done();
-        });
+      it('should call replaceTrack for each sender if tracks have same id', () => {
+        negotiator.replaceStream(newStream);
+
+        assert.equal(audioSender.replaceTrack.callCount, 0);
+
+        assert.equal(videoSender.replaceTrack.callCount, 0);
+      });
+    });
+
+    describe('new stream has fewer number of tracks', () => {
+      beforeEach(() => {
+        getVideoTracksStub.returns([]);
+        getAudioTracksStub.returns([]);
+      });
+
+      it('should call removeTrack for each sender', () => {
+        negotiator.replaceStream(newStream);
+
+        assert.equal(removeTrackStub.callCount, 2);
+        assert(removeTrackStub.calledWith(audioSender));
+        assert(removeTrackStub.calledWith(videoSender));
+      });
+    });
+
+    describe('new stream has larger number of tracks', () => {
+      beforeEach(() => {
+        getSendersStub.returns([audioSender]);
+
+        getVideoTracksStub.returns([videoTrack]);
+        getAudioTracksStub.returns([audioTrack]);
+      });
+
+      it('should not call replaceTrack for audio sender', () => {
+        negotiator.replaceStream(newStream);
+
+        assert.equal(audioSender.replaceTrack.callCount, 0);
+      });
+
+      it('should not call addTrack for audio sender', () => {
+        negotiator.replaceStream(newStream);
+
+        assert(!addTrackStub.calledWith(audioTrack));
+      });
+
+      it('should call addTrack for video sender', () => {
+        negotiator.replaceStream(newStream);
+
+        assert(addTrackStub.calledWith(videoTrack));
       });
     });
   });
@@ -714,11 +677,11 @@ describe('Negotiator', () => {
       const pc = (negotiator._pc = negotiator._createPeerConnection({}));
 
       negotiator._setupPCListeners();
+      assert.equal(typeof pc.ontrack, 'function');
       assert.equal(typeof pc.ondatachannel, 'function');
       assert.equal(typeof pc.onicecandidate, 'function');
       assert.equal(typeof pc.oniceconnectionstatechange, 'function');
       assert.equal(typeof pc.onnegotiationneeded, 'function');
-      assert.equal(typeof pc.onremovestream, 'function');
       assert.equal(typeof pc.onsignalingstatechange, 'function');
     });
 
@@ -730,6 +693,20 @@ describe('Negotiator', () => {
         negotiator = new Negotiator();
         pc = negotiator._pc = negotiator._createPeerConnection({});
         negotiator._setupPCListeners();
+      });
+
+      describe('ontrack', () => {
+        it("should emit 'addStream' with track", done => {
+          const dummyMediaStream = new MediaStream();
+          const ev = {
+            streams: [dummyMediaStream],
+          };
+          negotiator.on(Negotiator.EVENTS.addStream.key, stream => {
+            assert(stream, dummyMediaStream);
+            done();
+          });
+          pc.ontrack(ev);
+        });
       });
 
       describe('ondatachannel', () => {
@@ -851,57 +828,14 @@ describe('Negotiator', () => {
         });
 
         describe('if not originator', () => {
-          describe('if replaceStream has been called', () => {
-            beforeEach(() => {
-              negotiator._replaceStreamCalled = true;
+          it("should not emit 'negotiationNeeded'", done => {
+            negotiator.on(Negotiator.EVENTS.negotiationNeeded.key, () => {
+              assert.fail('Should not emit negotiationNeeded event');
             });
-            it('should call handleOffer', () => {
-              const handleOfferSpy = sinon.spy(negotiator, 'handleOffer');
-              assert.equal(handleOfferSpy.callCount, 0);
-              pc.onnegotiationneeded();
-              assert.equal(handleOfferSpy.callCount, 1);
-            });
+            pc.onnegotiationneeded();
+
+            setTimeout(done);
           });
-          describe("if replaceStream hasn't been called", () => {
-            beforeEach(() => {
-              negotiator._replaceStreamCalled = false;
-            });
-            it("should not emit 'negotiationNeeded'", done => {
-              negotiator.on(Negotiator.EVENTS.negotiationNeeded.key, () => {
-                assert.fail('Should not emit negotiationNeeded event');
-              });
-              pc.onnegotiationneeded();
-
-              setTimeout(done);
-            });
-          });
-        });
-      });
-
-      describe('onremovestream', () => {
-        const evt = { stream: 'stream' };
-        let logSpy;
-
-        beforeEach(() => {
-          logSpy = sinon.spy(logger, 'log');
-        });
-
-        afterEach(() => {
-          logSpy.restore();
-        });
-
-        it('should log the event', () => {
-          pc.onremovestream(evt);
-          logSpy.calledWith('`removestream` triggered');
-        });
-
-        it("should emit 'removeStream'", done => {
-          negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-            assert.equal(stream, evt.stream);
-            done();
-          });
-
-          pc.onremovestream(evt);
         });
       });
     });

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -693,20 +693,18 @@ describe('Negotiator', () => {
       pcStub.restore();
     });
 
-    it('should set "plan-b" with pcConfig', () => {
-      const pcConf = { sdpSemantics: 'unified-plan' };
+    it('should set "unified-plan" with pcConfig', () => {
+      const pcConf = { sdpSemantics: 'plan-b' };
       negotiator._createPeerConnection(pcConf);
 
-      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
-      assert.equal(pcConf.sdpSemantics, 'plan-b');
+      assert.equal(pcConf.sdpSemantics, 'unified-plan');
     });
 
     it('should set "plan-b" with empty pcConfig', () => {
       const pcConf = {};
       negotiator._createPeerConnection(pcConf);
 
-      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
-      assert.equal(pcConf.sdpSemantics, 'plan-b');
+      assert.equal(pcConf.sdpSemantics, 'unified-plan');
     });
   });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -105,7 +105,6 @@ describe('SFURoom', () => {
       sfuRoom._setupNegotiatorMessageHandlers();
 
       assert(onSpy.calledWith(Negotiator.EVENTS.addStream.key));
-      assert(onSpy.calledWith(Negotiator.EVENTS.removeStream.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceCandidate.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.answerCreated.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceConnectionFailed.key));
@@ -173,50 +172,6 @@ describe('SFURoom', () => {
 
             assert.deepEqual(sfuRoom._unknownStreams, { [stream.id]: stream });
           });
-        });
-      });
-
-      describe('removeStream', () => {
-        const stream = { id: 'streamId', peerId: peerId };
-        const otherStream = { id: 'otherStream', peerId: remotePeerId };
-
-        it('should delete the stream from remoteStreams', () => {
-          sfuRoom.remoteStreams[stream.id] = stream;
-          sfuRoom.remoteStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom.remoteStreams[stream.id], undefined);
-          assert.equal(sfuRoom.remoteStreams[otherStream.id], otherStream);
-        });
-
-        it('should delete the stream from _msidMap', () => {
-          sfuRoom._msidMap[stream.id] = stream.peerId;
-          sfuRoom._msidMap[otherStream.id] = otherStream.peerId;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._msidMap[stream.id], undefined);
-          assert.equal(sfuRoom._msidMap[otherStream.id], otherStream.peerId);
-        });
-
-        it('should delete the stream from _unknownStreams', () => {
-          sfuRoom._unknownStreams[stream.id] = stream;
-          sfuRoom._unknownStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._unknownStreams[stream.id], undefined);
-          assert.equal(sfuRoom._unknownStreams[otherStream.id], otherStream);
-        });
-
-        it('should emit a removeStream event', done => {
-          sfuRoom.on(SFURoom.EVENTS.removeStream.key, removedStream => {
-            assert.equal(removedStream, stream);
-            done();
-          });
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
         });
       });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -190,11 +190,23 @@ describe('SFURoom', () => {
       });
 
       describe('answerCreated', () => {
+        const answer = {
+          type: 'answer',
+          sdp: 'v=0\r\na=msid-semantic: WMS xxxxxx\r\n',
+        };
         it('should emit an answer message event', done => {
-          const answer = {};
           sfuRoom.on(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage => {
             assert.equal(answerMessage.roomName, sfuRoomName);
             assert.equal(answerMessage.answer, answer);
+            done();
+          });
+
+          sfuRoom._negotiator.emit(Negotiator.EVENTS.answerCreated.key, answer);
+        });
+
+        it('should include `a=msid-semantic:WMS *` in sending answer SDP', done => {
+          sfuRoom.on(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage => {
+            assert(answerMessage.answer.sdp.includes('a=msid-semantic:WMS *'));
             done();
           });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -195,7 +195,6 @@ describe('SFURoom', () => {
           sfuRoom.on(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage => {
             assert.equal(answerMessage.roomName, sfuRoomName);
             assert.equal(answerMessage.answer, answer);
-            assert.equal(answerMessage.sdpSemantics, 'unified-plan');
             done();
           });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -195,6 +195,7 @@ describe('SFURoom', () => {
           sfuRoom.on(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage => {
             assert.equal(answerMessage.roomName, sfuRoomName);
             assert.equal(answerMessage.answer, answer);
+            assert.equal(answerMessage.sdpSemantics, 'unified-plan');
             done();
           });
 


### PR DESCRIPTION
## Internal/Private changes
- use track-based APIs only
  - `addStream()` -> `addTrack()`
  - `replaceTrack()` via `RTCRtpSender`
  - remove `onremovestream` event handler
- clean up not-used flag variables
- force `sdpSemantics` to `unified-plan`
- not send browser name with offer SDP anymore
- munge answer SDP to be treated as `unifined-plan` in signaling server

## External/Public changes
- `removeStream` event is not fired anymore
  - on `SFURoom`, `MeshRoom`, `MediaConnection`
  - use `peerLeave` or `close` event instead
