### PR TITLE
dev: catch invalid-id error

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -216,7 +216,7 @@ class Peer extends EventEmitter {
    * @type {boolean} The open status.
    */
   get open() {
-    return this.socket.isOpen;
+    return this.socket && this.socket.isOpen;
   }
 
   /**

--- a/tests/peer.js
+++ b/tests/peer.js
@@ -170,6 +170,7 @@ describe('Peer', () => {
           key: apiKey,
         });
       } catch (e) {
+        assert(e.message.includes('is invalid'));
         assert.equal(peer, undefined);
         done();
       }
@@ -182,6 +183,7 @@ describe('Peer', () => {
           key: 'wrong',
         });
       } catch (e) {
+        assert(e.message.includes('is invalid'));
         assert.equal(peer, undefined);
         done();
       }


### PR DESCRIPTION
```js
try {
  const peer = new Peer('invalid.id', { key: 'valid-key' });
} catch(err) {
  err.message; // <=
}
```

Currently, this code ends up with `Uncaught TypeError: Cannot read property 'isOpen' of undefined`.

This PR fixes this into `ID "invalid.id" is invalid`. = error is handled properly