### PR TITLE
dev: Safari 12.1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,6 @@ module.exports = {
     mocha: true,
   },
   globals: {
-    RTCRtpSender: true,
+    RTCRtpTransceiver: true,
   },
 };

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -154,6 +154,8 @@ class SFURoom extends Room {
     });
 
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
+      // If we specify sdpSemantics: unified-plan in Chrome, need to add Chrome here
+      // or fix some lines to ensure SDP to be recognized by SFU.
       if (util.isUnifiedPlanSafari()) {
         answer.sdp = sdpUtil.pretendUnifiedPlan(answer.sdp);
       }

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -76,7 +76,6 @@ class SFURoom extends Room {
      *
      * Chrome: plan-b(controlled by us)
      * Firefox: unified-plan
-     * Safari ~12.0: plan-b
      * Safari 12.1~: plan-b
      * Safari 12.1~: unified-plan(if user enables)
      *
@@ -84,6 +83,7 @@ class SFURoom extends Room {
      * We don't need to convert the answer back to Unified Plan because the server can handle Plan B.
      */
     const browserInfo = util.detectBrowser();
+    // Means Chrome or Safari(plan-b)
     if (!(browserInfo.name === 'firefox' || util.isUnifiedPlanSafari())) {
       offer = sdpUtil.unifiedToPlanB(offer);
     }

--- a/src/shared/sdpUtil.js
+++ b/src/shared/sdpUtil.js
@@ -82,6 +82,34 @@ class SdpUtil {
   }
 
   /**
+   * Our signaling server determines client's SDP semantics
+   * by checking answer SDP includes `a=msid-semantic:WMS *` or NOT.
+   *
+   * Currenly, Firefox prints exact string,
+   * but Chrome does not. even using `unified-plan`.
+   * Therefore Chrome needs to pretend Firefox to join SFU rooms.
+   *
+   * At a glance, using `sdp-transform` is better choice to munge SDP,
+   * but if you do so, it prints `a=msid-semantic: WMS *`.
+   * The problem is the space before the word `WMS`,
+   * our signaling server can not handle this as `unified-plan` SDP...
+   *
+   * @param {string} sdp - A SDP.
+   * @return {string} A SDP which has `a=msid-semantic:WMS *`.
+   */
+  pretendUnifiedPlan(sdp) {
+    const delimiter = '\r\n';
+    return sdp
+      .split(delimiter)
+      .map(line => {
+        return line.startsWith('a=msid-semantic')
+          ? 'a=msid-semantic:WMS *'
+          : line;
+      })
+      .join(delimiter);
+  }
+
+  /**
    * Remove codecs except the codec passed as argument and return the SDP
    *
    * @param {string} sdp - A SDP.

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -100,6 +100,7 @@ function detectBrowser() {
 /**
  * Safari 12.1 may use plan-b sdp and also unified-plan sdp.
  * It depends on user settings.
+ * See https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/
  *
  * @return {boolean} Browser is Safari 12.1 or later and enables unified-plan OR NOT
  */

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -97,6 +97,26 @@ function detectBrowser() {
   };
 }
 
+/**
+ * Safari 12.1 may use plan-b sdp and also unified-plan sdp.
+ * It depends on user settings.
+ *
+ * @return {boolean} Browser is Safari 12.1 or later and enables unified-plan OR NOT
+ */
+function isUnifiedPlanSafari() {
+  const { name, major, minor } = detectBrowser();
+
+  if (
+    name === 'safari' &&
+    (major >= 12 && minor >= 1) &&
+    RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 export default {
   validateId,
   validateKey,
@@ -106,4 +126,5 @@ export default {
   blobToArrayBuffer,
   isSecure,
   detectBrowser,
+  isUnifiedPlanSafari,
 };


### PR DESCRIPTION
To support Safari(mainly for 12.1).

Thus, target browsers and it's sdp semantics are ...

| browser | version | sdpSemantics | memo             |
| ------- | ------- | ------------ | ---------------- |
| Chrome  | *       | plan-b       | controlled by us |
| Firefox | *       | unified-plan |                  |
| Safari  | ~12.0   | plan-b       | not support                 |
| Safari  | 12.1~   | plan-b       | default          |
| Safari  | 12.1~   | unified-plan | if user changed  | 

This PR is needed to enter SFU.