### PR TITLE
Remove legacy stream-based API

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -78,7 +78,6 @@ class Connection extends EventEmitter {
   async handleAnswer(answerMessage) {
     if (this._pcAvailable) {
       await this._negotiator.handleAnswer(answerMessage.answer);
-      this._negotiator.setRemoteBrowser(answerMessage.browser);
       this.open = true;
       this._handleQueuedMessages();
     } else {
@@ -176,14 +175,12 @@ class Connection extends EventEmitter {
    * @private
    */
   _setupNegotiatorMessageHandlers() {
-    const browserInfo = util.detectBrowser();
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
       const connectionAnswer = {
         answer: answer,
         dst: this.remoteId,
         connectionId: this.id,
         connectionType: this.type,
-        browser: browserInfo,
       };
       this.emit(Connection.EVENTS.answer.key, connectionAnswer);
     });
@@ -195,7 +192,6 @@ class Connection extends EventEmitter {
         connectionId: this.id,
         connectionType: this.type,
         metadata: this.metadata,
-        browser: browserInfo,
       };
       if (this.serialization) {
         connectionOffer.serialization = this.serialization;

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -71,11 +71,6 @@ class DataConnection extends Connection {
     // Messages stored by peer because DC was not ready yet
     this._queuedMessages = this._options.queuedMessages || [];
 
-    // Maybe don't need this anymore
-    if (this._options.payload) {
-      this._peerBrowser = this._options.payload.browser;
-    }
-
     // This replaces the PeerJS 'initialize' method
     this._negotiator.on(Negotiator.EVENTS.dcCreated.key, dc => {
       this._dc = dc;

--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -109,7 +109,6 @@ class MediaConnection extends Connection {
       videoReceiveEnabled: options.videoReceiveEnabled,
       audioReceiveEnabled: options.audioReceiveEnabled,
     });
-    this._negotiator.setRemoteBrowser(this._options.payload.browser);
     this._pcAvailable = true;
 
     this._handleQueuedMessages();

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -66,7 +66,6 @@ class Negotiator extends EventEmitter {
     this._videoCodec = options.videoCodec;
     this._type = options.type;
     this._recvonlyState = this._getReceiveOnlyState(options);
-    this._remoteBrowser = {};
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -90,10 +89,6 @@ class Negotiator extends EventEmitter {
     } else {
       await this.handleOffer(options.offer);
     }
-  }
-
-  setRemoteBrowser(browser) {
-    this._remoteBrowser = browser;
   }
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -93,7 +93,10 @@ class Negotiator extends EventEmitter {
 
   /**
    * Replace the stream being sent with a new one.
+   * Video and audio tracks are updated per track by using `{add|replace|remove}Track` methods.
+   * We assume that there is at most 1 audio and at most 1 video in local stream.
    * @param {MediaStream} newStream - The stream to replace the old stream with.
+   * @private
    */
   replaceStream(newStream) {
     // If negotiator is null
@@ -103,7 +106,45 @@ class Negotiator extends EventEmitter {
     }
 
     this._isNegotiationAllowed = true;
-    this._replacePerTrack(newStream);
+
+    const _this = this;
+    const vTracks = newStream.getVideoTracks();
+    const aTracks = newStream.getAudioTracks();
+
+    const senders = this._pc.getSenders();
+    const vSender = senders.find(sender => sender.track.kind === 'video');
+    const aSender = senders.find(sender => sender.track.kind === 'audio');
+
+    _updateSenderWithTrack(vSender, vTracks[0], newStream);
+    _updateSenderWithTrack(aSender, aTracks[0], newStream);
+
+    /**
+     * Replace a track being sent with a new one.
+     * @param {RTCRtpSender} sender - The sender which type is video or audio.
+     * @param {MediaStreamTrack} track - The track of new stream.
+     * @param {MediaStream} stream - The stream which contains the track.
+     * @private
+     */
+    function _updateSenderWithTrack(sender, track, stream) {
+      if (track === undefined && sender === undefined) {
+        return;
+      }
+      // remove video or audio sender if not passed
+      if (track === undefined) {
+        _this._pc.removeTrack(sender);
+        return;
+      }
+      // if passed, replace track or create sender
+      if (sender === undefined) {
+        _this._pc.addTrack(track, stream);
+        return;
+      }
+      // if track was not replaced, do nothing
+      if (sender.track.id === track.id) {
+        return;
+      }
+      sender.replaceTrack(track);
+    }
   }
 
   /**
@@ -210,7 +251,7 @@ class Negotiator extends EventEmitter {
     const pc = this._pc;
 
     pc.ontrack = evt => {
-      logger.log('Received remote media stream');
+      logger.log('Received remote media stream track');
       evt.streams.forEach(stream => {
         this.emit(Negotiator.EVENTS.addStream.key, stream);
       });
@@ -513,54 +554,6 @@ class Negotiator extends EventEmitter {
     }
 
     return state;
-  }
-
-  /**
-   * Replace the stream being sent with a new one.
-   * Video and audio are replaced per track by using `xxxTrack` methods.
-   * We assume that there is at most 1 audio and at most 1 video in local stream.
-   * @param {MediaStream} newStream - The stream to replace the old stream with.
-   * @private
-   */
-  _replacePerTrack(newStream) {
-    const _this = this;
-    const vTracks = newStream.getVideoTracks();
-    const aTracks = newStream.getAudioTracks();
-
-    const senders = this._pc.getSenders();
-    const vSender = senders.find(sender => sender.track.kind === 'video');
-    const aSender = senders.find(sender => sender.track.kind === 'audio');
-
-    _updateSenderWithTrack(vSender, vTracks[0], newStream);
-    _updateSenderWithTrack(aSender, aTracks[0], newStream);
-
-    /**
-     * Replace a track being sent with a new one.
-     * @param {RTCRtpSender} sender - The sender which type is video or audio.
-     * @param {MediaStreamTrack} track - The track of new stream.
-     * @param {MediaStream} stream - The stream which contains the track.
-     * @private
-     */
-    function _updateSenderWithTrack(sender, track, stream) {
-      if (track === undefined && sender === undefined) {
-        return;
-      }
-      // remove video or audio sender if not passed
-      if (track === undefined) {
-        _this._pc.removeTrack(sender);
-        return;
-      }
-      // if passed, replace track or create sender
-      if (sender === undefined) {
-        _this._pc.addTrack(track, stream);
-        return;
-      }
-      // if track was not replaced, do nothing
-      if (sender.track.id === track.id) {
-        return;
-      }
-      sender.replaceTrack(track);
-    }
   }
 
   /**

--- a/tests/peer/dataConnection.js
+++ b/tests/peer/dataConnection.js
@@ -67,14 +67,12 @@ describe('DataConnection', () => {
       const label = 'label';
       const dcInit = { ordered: false };
       const serialization = 'binary';
-      const peerBrowser = 'browser';
       const metadata = 'meta';
       const options = {
         label: label,
         dcInit: dcInit,
         serialization: serialization,
         metadata: metadata,
-        payload: { browser: peerBrowser },
       };
 
       const dc = new DataConnection(id, options);
@@ -85,7 +83,6 @@ describe('DataConnection', () => {
       assert.equal(dc.dcInit, dcInit);
       assert.equal(dc.serialization, serialization);
       assert.equal(dc.metadata, metadata);
-      assert.equal(dc._peerBrowser, peerBrowser);
       assert.equal(dc._options, options);
     });
 


### PR DESCRIPTION
### removed
- `addStream()`
- `replaceStream()`
- `removeStream()`
- `onaddstream`

Therefore we do not need to send browser info anymore.

### not removed
- `onremovestream`
  - remove this means BREAKING CHANGE!
- `createOffer(legacyOptions)`
  - not related to stream-based API but it is legacy too

We can remove these by supporting unified-plan only in Chrome.
The plan-b Safari does not use them.