### PR TITLE
Fixed that replace *all* server domein for staging environment #168

### DIFF
--- a/scripts/ensure-branch/fetch-base-branch.js
+++ b/scripts/ensure-branch/fetch-base-branch.js
@@ -1,12 +1,12 @@
 const Octokit = require('@octokit/rest');
 
-module.exports = async function fetchBaseBranch(number, { GITHUB_TOKEN }) {
+module.exports = async function fetchBaseBranch(prNumber, { GITHUB_TOKEN }) {
   const octokit = new Octokit({ auth: `token ${GITHUB_TOKEN}` });
 
   const { data: { base: { ref } } } = await octokit.pulls.get({
     owner: 'skyway',
     repo: 'skyway-js-sdk',
-    number,
+    pull_number: prNumber,
   });
 
   return ref;

--- a/scripts/shared/replace-sdk-server-domain.js
+++ b/scripts/shared/replace-sdk-server-domain.js
@@ -3,7 +3,7 @@ const replace = require('replace-in-file');
 module.exports = async function replaceSdkServerDomain(domain) {
   const changes = await replace({
     files: './dist/*.js',
-    from: 'webrtc.ecl.ntt.com',
+    from: /webrtc\.ecl\.ntt\.com/g,
     to: domain,
   });
 


### PR DESCRIPTION
We should replace all of productio domain to staging domain.
If we give string without g(global) option, replace method will replace first occurrence only.