### PR TITLE
Fix unified-plan replace stream error

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -112,8 +112,12 @@ class Negotiator extends EventEmitter {
     const aTracks = newStream.getAudioTracks();
 
     const senders = this._pc.getSenders();
-    const vSender = senders.find(sender => sender.track.kind === 'video');
-    const aSender = senders.find(sender => sender.track.kind === 'audio');
+    const vSender = senders.find(
+      sender => sender.track && sender.track.kind === 'video'
+    );
+    const aSender = senders.find(
+      sender => sender.track && sender.track.kind === 'audio'
+    );
 
     _updateSenderWithTrack(vSender, vTracks[0], newStream);
     _updateSenderWithTrack(aSender, aTracks[0], newStream);


### PR DESCRIPTION
This PR fixes #172 

- Replace
- "camera only stream" to "display only stream"
  - OR "audio only stream " to "same audio only stream but cloned"
  - OR something like that..
- ends up with `TypeError: "sender.track is null"`
- when using SFU in Firefox.

We know there are some potential cases it does not work well, but in this PR, we keep away from fixing it.