### PR TITLE
Implement getPeerConnection

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -136,6 +136,14 @@ class Connection extends EventEmitter {
   }
 
   /**
+   * Gives a promise which resolves with data providing statistics about either
+   * the overall of RTCPeerConnection.
+   */
+  async getStats() {
+    return this._negotiator._pc.getStats();
+  }
+
+  /**
    * Process messages received before the RTCPeerConnection is ready.
    * @private
    */

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -141,6 +141,10 @@ class Connection extends EventEmitter {
    * @param {boolean} [inUse=true] - Set to true and it gives statistics only in use by the connection.
    */
   async getStats(inUse = true) {
+    if (!this.open) {
+      return null;
+    }
+
     if (!inUse) {
       return this._negotiator._pc.getStats();
     }

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -137,10 +137,35 @@ class Connection extends EventEmitter {
 
   /**
    * Gives a promise which resolves with data providing statistics about either
-   * the overall of RTCPeerConnection.
+   * the overall of RTCPeerConnection or only using in the connection.
+   * @param {boolean} [inUse=true] - Set to true and it gives statistics only in use by the connection.
    */
-  async getStats() {
-    return this._negotiator._pc.getStats();
+  async getStats(inUse = true) {
+    if (!inUse) {
+      return this._negotiator._pc.getStats();
+    }
+
+    const inUseStats = new Map();
+
+    const receivers = this._negotiator._pc.getReceivers();
+    for (const receiver of receivers) {
+      const stats = await receiver.getStats();
+
+      for (const [key, value] of stats.entries()) {
+        inUseStats.set(key, value);
+      }
+    }
+
+    const senders = this._negotiator._pc.getSenders();
+    for (const sender of senders) {
+      const stats = await sender.getStats();
+
+      for (const [key, value] of stats.entries()) {
+        inUseStats.set(key, value);
+      }
+    }
+
+    return inUseStats;
   }
 
   /**

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -136,40 +136,13 @@ class Connection extends EventEmitter {
   }
 
   /**
-   * Gives a promise which resolves with data providing statistics about either
-   * the overall of RTCPeerConnection or only using in the connection.
-   * @param {boolean} [inUse=true] - Set to true and it gives statistics only in use by the connection.
+   * Gives a RTCPeerConnection.
    */
-  async getStats(inUse = true) {
+  getPeerConnection() {
     if (!this.open) {
       return null;
     }
-
-    if (!inUse) {
-      return this._negotiator._pc.getStats();
-    }
-
-    const inUseStats = new Map();
-
-    const receivers = this._negotiator._pc.getReceivers();
-    for (const receiver of receivers) {
-      const stats = await receiver.getStats();
-
-      for (const [key, value] of stats.entries()) {
-        inUseStats.set(key, value);
-      }
-    }
-
-    const senders = this._negotiator._pc.getSenders();
-    for (const sender of senders) {
-      const stats = await sender.getStats();
-
-      for (const [key, value] of stats.entries()) {
-        inUseStats.set(key, value);
-      }
-    }
-
-    return inUseStats;
+    return this._negotiator._pc;
   }
 
   /**

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -380,12 +380,30 @@ describe('MediaConnection', () => {
   });
 
   describe('getStats', () => {
-    it('should call RTCPeerConneciton.getStats', () => {
+    it('should call RTCPeerConneciton.getStats upon called with false', async () => {
       const mc = new MediaConnection('remoteId', { stream: {} });
 
-      mc.getStats();
+      await mc.getStats(false);
 
       assert(getStatsSpy.calledOnce);
+    });
+
+    it('should call track-specific getStats upon called with true', async () => {
+      const mc = new MediaConnection('remoteId', { stream: {} });
+      const transceiverStub = sinon.stub();
+      const getStatsStub = sinon.stub();
+      getStatsStub.returns(new Map()); // getStats returns a maplike object
+
+      transceiverStub.returns([{ getStats: getStatsStub }]);
+      mc._negotiator._pc = {
+        getReceivers: transceiverStub,
+        getSenders: transceiverStub,
+      };
+
+      await mc.getStats(true);
+
+      // call getStats about a receiver and a sender in this case.
+      assert(getStatsStub.calledTwice);
     });
   });
 

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -17,7 +17,6 @@ describe('MediaConnection', () => {
   let answerSpy;
   let candidateSpy;
   let replaceSpy;
-  let getStatsSpy;
 
   beforeEach(() => {
     stub = sinon.stub();
@@ -26,7 +25,6 @@ describe('MediaConnection', () => {
     answerSpy = sinon.spy();
     candidateSpy = sinon.spy();
     replaceSpy = sinon.spy();
-    getStatsSpy = sinon.spy();
 
     stub.returns({
       on: function(event, callback) {
@@ -41,9 +39,6 @@ describe('MediaConnection', () => {
       handleCandidate: candidateSpy,
       replaceStream: replaceSpy,
       setRemoteBrowser: sinon.spy(),
-      _pc: {
-        getStats: getStatsSpy,
-      },
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;
@@ -59,7 +54,6 @@ describe('MediaConnection', () => {
     answerSpy.resetHistory();
     candidateSpy.resetHistory();
     replaceSpy.resetHistory();
-    getStatsSpy.resetHistory();
   });
 
   describe('Constructor', () => {
@@ -379,31 +373,25 @@ describe('MediaConnection', () => {
     });
   });
 
-  describe('getStats', () => {
-    it('should call RTCPeerConneciton.getStats upon called with false', async () => {
+  describe('getPeerConnection', () => {
+    it('should return null when Connection status is not open', async () => {
       const mc = new MediaConnection('remoteId', { stream: {} });
+      mc._negotiator._pc = {};
+      mc.open = false;
 
-      await mc.getStats(false);
+      const pc = mc.getPeerConnection();
 
-      assert(getStatsSpy.calledOnce);
+      assert.equal(pc, null);
     });
 
-    it('should call track-specific getStats upon called with true', async () => {
+    it('should return RTCPeerConnection object when Connection status is open', async () => {
       const mc = new MediaConnection('remoteId', { stream: {} });
-      const transceiverStub = sinon.stub();
-      const getStatsStub = sinon.stub();
-      getStatsStub.returns(new Map()); // getStats returns a maplike object
+      mc._negotiator._pc = {};
+      mc.open = true;
 
-      transceiverStub.returns([{ getStats: getStatsStub }]);
-      mc._negotiator._pc = {
-        getReceivers: transceiverStub,
-        getSenders: transceiverStub,
-      };
+      const pc = await mc.getPeerConnection();
 
-      await mc.getStats(true);
-
-      // call getStats about a receiver and a sender in this case.
-      assert(getStatsStub.calledTwice);
+      assert.deepEqual(pc, {});
     });
   });
 

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -17,6 +17,7 @@ describe('MediaConnection', () => {
   let answerSpy;
   let candidateSpy;
   let replaceSpy;
+  let getStatsSpy;
 
   beforeEach(() => {
     stub = sinon.stub();
@@ -25,6 +26,7 @@ describe('MediaConnection', () => {
     answerSpy = sinon.spy();
     candidateSpy = sinon.spy();
     replaceSpy = sinon.spy();
+    getStatsSpy = sinon.spy();
 
     stub.returns({
       on: function(event, callback) {
@@ -39,6 +41,9 @@ describe('MediaConnection', () => {
       handleCandidate: candidateSpy,
       replaceStream: replaceSpy,
       setRemoteBrowser: sinon.spy(),
+      _pc: {
+        getStats: getStatsSpy,
+      },
     });
     // hoist statics
     stub.EVENTS = Negotiator.EVENTS;
@@ -54,6 +59,7 @@ describe('MediaConnection', () => {
     answerSpy.resetHistory();
     candidateSpy.resetHistory();
     replaceSpy.resetHistory();
+    getStatsSpy.resetHistory();
   });
 
   describe('Constructor', () => {
@@ -370,6 +376,16 @@ describe('MediaConnection', () => {
       assert.deepEqual(mc._queuedMessages, [message1, message2]);
       assert(answerSpy.called === false);
       assert(candidateSpy.called === false);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should call RTCPeerConneciton.getStats', () => {
+      const mc = new MediaConnection('remoteId', { stream: {} });
+
+      mc.getStats();
+
+      assert(getStatsSpy.calledOnce);
     });
   });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -15,7 +15,6 @@ describe('Negotiator', () => {
   });
 
   describe('startConnection', () => {
-    let newPcStub;
     let pcStub;
     let addTrackSpy;
     let createDCSpy;
@@ -25,14 +24,12 @@ describe('Negotiator', () => {
     let setRemoteDescStub;
 
     beforeEach(() => {
-      newPcStub = sinon.stub();
       addTrackSpy = sinon.spy();
       createDCSpy = sinon.spy();
       pcStub = {
         addTrack: addTrackSpy,
         createDataChannel: createDCSpy,
       };
-      newPcStub.returns(pcStub);
 
       negotiator = new Negotiator();
       handleOfferSpy = sinon.spy(negotiator, 'handleOffer');
@@ -43,7 +40,6 @@ describe('Negotiator', () => {
     });
 
     afterEach(() => {
-      newPcStub.reset();
       addTrackSpy.resetHistory();
       createDCSpy.resetHistory();
       handleOfferSpy.resetHistory();


### PR DESCRIPTION
This PR includes below change.
- Implement API that returns RTCPeerConnection.
- Add test for mc.getPeerConnection.
- Remove API that returns RTCStats.
- Remove test for mc.getStats.