### PR TITLE
Fix SDP parsing error on unified-plan iOS

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -108,7 +108,7 @@ function isUnifiedPlanSafari() {
   const { name, major, minor } = detectBrowser();
 
   if (
-    name === 'safari' &&
+    (name === 'safari' || name === 'ios') &&
     (major >= 12 && minor >= 1) &&
     RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
   ) {


### PR DESCRIPTION
Hence `detect-browser` recognize iOS Safari as `ios`, we need to take this browser name as same as macOS's Safari.