### PR TITLE
Prevent options.token overriding

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -64,7 +64,6 @@ class Peer extends EventEmitter {
     const defaultOptions = {
       debug: logger.LOG_LEVELS.NONE,
       secure: true,
-      token: util.randomToken(),
       config: config.defaultConfig,
       turn: true,
 
@@ -74,6 +73,8 @@ class Peer extends EventEmitter {
     };
 
     this.options = Object.assign({}, defaultOptions, options);
+    // do not override by options
+    this.options.token = util.randomToken();
 
     logger.setLogLevel(this.options.debug);
 

--- a/tests/peer.js
+++ b/tests/peer.js
@@ -141,6 +141,16 @@ describe('Peer', () => {
       assert.equal(peer.options.turn, true);
     });
 
+    it('should not override options.token', () => {
+      const peer = new Peer({
+        key: apiKey,
+        token: 'hoge',
+      });
+
+      // token is random value
+      assert.notEqual(peer.options.token, 'hoge');
+    });
+
     describe('Signaling server options', () => {
       describe('when host option is provided', () => {
         it('should create Peer object with provided host', () => {


### PR DESCRIPTION
```js
new Peer({ key: 'your-valid-key', token: '' })
```

This code ends up with `Uncaught Error: PeerId "xxxx" is already in use.`
(Of course this PeerId is not used yet!!)

This PR fixes it.