### PR TITLE
Transition to unified-plan

### DIFF
--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -4,7 +4,7 @@ import Negotiator from './negotiator';
 import Connection from './connection';
 import logger from '../shared/logger';
 
-const MCEvents = new Enum(['stream', 'removeStream']);
+const MCEvents = new Enum(['stream']);
 
 MCEvents.extend(Connection.EVENTS.enums);
 
@@ -143,16 +143,6 @@ class MediaConnection extends Connection {
 
       this.emit(MediaConnection.EVENTS.stream.key, remoteStream);
     });
-
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, remoteStream => {
-      logger.log('Stream removed', remoteStream);
-
-      // Don't unset if a new stream has already replaced the old one
-      if (this.remoteStream === remoteStream) {
-        this.remoteStream = null;
-      }
-      this.emit(MediaConnection.EVENTS.removeStream.key, remoteStream);
-    });
   }
 
   /**
@@ -167,13 +157,6 @@ class MediaConnection extends Connection {
    * MediaStream received from peer.
    *
    * @event MediaConnection#stream
-   * @type {MediaStream}
-   */
-
-  /**
-   * MediaStream from peer was removed.
-   *
-   * @event MediaConnection#removeStream
    * @type {MediaStream}
    */
 }

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -388,10 +388,6 @@ class MeshRoom extends Room {
         remoteStream.peerId = connection.remoteId;
         this.emit(MeshRoom.EVENTS.stream.key, remoteStream);
       });
-
-      connection.on(MediaConnection.EVENTS.removeStream.key, remoteStream => {
-        this.emit(MeshRoom.EVENTS.removeStream.key, remoteStream);
-      });
     }
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -347,10 +347,7 @@ class Negotiator extends EventEmitter {
     let offer;
 
     try {
-      // DataConnection
-      if (this._type !== 'media') {
-        offer = await this._pc.createOffer();
-      }
+      offer = await this._pc.createOffer();
     } catch (err) {
       err.type = 'webrtc';
       logger.error(err);

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -3,7 +3,6 @@ import Enum from 'enum';
 
 import sdpUtil from '../shared/sdpUtil';
 import logger from '../shared/logger';
-import util from '../shared/util';
 
 const NegotiatorEvents = new Enum([
   'addStream',
@@ -57,7 +56,7 @@ class Negotiator extends EventEmitter {
    * @return {Promise<void>} Promise that resolves when starting is done.
    */
   async startConnection(options = {}) {
-    this._pc = this._createPeerConnection(options.pcConfig);
+    this._pc = new RTCPeerConnection(options.pcConfig);
     this._setupPCListeners();
     this.originator = options.originator;
     this._audioBandwidth = options.audioBandwidth;
@@ -65,7 +64,6 @@ class Negotiator extends EventEmitter {
     this._audioCodec = options.audioCodec;
     this._videoCodec = options.videoCodec;
     this._type = options.type;
-    this._recvonlyState = this._getReceiveOnlyState(options);
 
     if (this._type === 'media') {
       if (options.stream) {
@@ -74,8 +72,11 @@ class Negotiator extends EventEmitter {
         });
       } else if (this.originator) {
         // This means the peer wants to create offer SDP with `recvonly`
-        const offer = await this._makeOfferSdp();
-        await this._setLocalDescription(offer);
+        const recvonlyState = this._getReceiveOnlyState(options);
+        recvonlyState.audio &&
+          this._pc.addTransceiver('audio', { direction: 'recvonly' });
+        recvonlyState.video &&
+          this._pc.addTransceiver('video', { direction: 'recvonly' });
       }
     }
 
@@ -226,28 +227,6 @@ class Negotiator extends EventEmitter {
   }
 
   /**
-   * Create new RTCPeerConnection.
-   * @param {object} pcConfig - A RTCConfiguration dictionary for the RTCPeerConnection.
-   * @return {RTCPeerConnection} An instance of RTCPeerConnection.
-   * @private
-   */
-  _createPeerConnection(pcConfig = {}) {
-    logger.log('Creating RTCPeerConnection');
-
-    const browserInfo = util.detectBrowser();
-
-    // If browser is Chrome and over 69, it has addTransceiver but does not work without unified-plan option.
-    // SkyWay has not supported unified-plan.
-    this._isAddTransceiverAvailable =
-      typeof RTCPeerConnection.prototype.addTransceiver === 'function' &&
-      browserInfo.name !== 'chrome';
-
-    // Force plan-b for SFU, until we finish unified-plan support.
-    pcConfig.sdpSemantics = 'plan-b';
-    return new RTCPeerConnection(pcConfig);
-  }
-
-  /**
    * Set up event handlers of RTCPeerConnection events.
    * @private
    */
@@ -363,23 +342,6 @@ class Negotiator extends EventEmitter {
       // DataConnection
       if (this._type !== 'media') {
         offer = await this._pc.createOffer();
-        // MediaConnection
-      } else {
-        if (this._isAddTransceiverAvailable) {
-          this._recvonlyState.audio &&
-            this._pc.addTransceiver('audio', { direction: 'recvonly' });
-          this._recvonlyState.video &&
-            this._pc.addTransceiver('video', { direction: 'recvonly' });
-          offer = await this._pc.createOffer();
-        } else {
-          const offerOptions = {};
-          // the offerToReceiveXXX options are defined in the specs as boolean but `undefined` acts differently from false
-          this._recvonlyState.audio &&
-            (offerOptions.offerToReceiveAudio = true);
-          this._recvonlyState.video &&
-            (offerOptions.offerToReceiveVideo = true);
-          offer = await this._pc.createOffer(offerOptions);
-        }
       }
     } catch (err) {
       err.type = 'webrtc';

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -55,7 +55,7 @@ class Negotiator extends EventEmitter {
    * @return {Promise<void>} Promise that resolves when starting is done.
    */
   async startConnection(options = {}) {
-    this._pc = new RTCPeerConnection(options.pcConfig);
+    this._pc = this._createPeerConnection(options.pcConfig);
     this._setupPCListeners();
     this.originator = options.originator;
     this._audioBandwidth = options.audioBandwidth;
@@ -224,6 +224,17 @@ class Negotiator extends EventEmitter {
       this._pc.close();
     }
     this._pc = null;
+  }
+
+  /**
+   * Create new RTCPeerConnection.
+   * @param {object} pcConfig - A RTCConfiguration dictionary for the RTCPeerConnection.
+   * @return {RTCPeerConnection} An instance of RTCPeerConnection.
+   * @private
+   */
+  _createPeerConnection(pcConfig = {}) {
+    logger.log('Creating RTCPeerConnection');
+    return new RTCPeerConnection(pcConfig);
   }
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -234,6 +234,8 @@ class Negotiator extends EventEmitter {
    */
   _createPeerConnection(pcConfig = {}) {
     logger.log('Creating RTCPeerConnection');
+    // prevent from user passing plan-b
+    pcConfig.sdpSemantics = 'unified-plan';
     return new RTCPeerConnection(pcConfig);
   }
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -6,7 +6,6 @@ import logger from '../shared/logger';
 
 const NegotiatorEvents = new Enum([
   'addStream',
-  'removeStream',
   'dcCreated',
   'offerCreated',
   'answerCreated',
@@ -306,11 +305,6 @@ class Negotiator extends EventEmitter {
 
         this._replaceStreamCalled = false;
       }
-    };
-
-    pc.onremovestream = evt => {
-      logger.log('`removestream` triggered');
-      this.emit(Negotiator.EVENTS.removeStream.key, evt.stream);
     };
 
     pc.onsignalingstatechange = () => {

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -64,6 +64,7 @@ class Negotiator extends EventEmitter {
     this._videoCodec = options.videoCodec;
     this._type = options.type;
 
+    // Trigger negotiationneeded event
     if (this._type === 'media') {
       if (options.stream) {
         options.stream.getTracks().forEach(track => {

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -3,7 +3,6 @@ import Enum from 'enum';
 
 const Events = [
   'stream',
-  'removeStream',
   'open',
   'close',
   'peerJoin',

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -145,10 +145,11 @@ class SFURoom extends Room {
     });
 
     this._negotiator.on(Negotiator.EVENTS.answerCreated.key, answer => {
-      // If we specify sdpSemantics: unified-plan in Chrome, need to add Chrome here
-      // or fix some lines to ensure SDP to be recognized by SFU.
-      if (util.isUnifiedPlanSafari()) {
-        answer.sdp = sdpUtil.pretendUnifiedPlan(answer.sdp);
+      // If we use unified-plan SDP and send it to our SFU,
+      // of course it must be treated as unified-plan SDP too.
+      // We need to ensure it for some reason.(see its implementation)
+      if (!util.isPlanBSafari()) {
+        answer.sdp = sdpUtil.ensureUnifiedPlan(answer.sdp);
       }
 
       const answerMessage = {

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -74,17 +74,16 @@ class SFURoom extends Room {
      * Our SFU returns unified-plan SDP.
      * Our support browsers and sdp semantics relations are
      *
-     * Chrome: plan-b(controlled by us)
+     * Chrome: unified-plan
      * Firefox: unified-plan
      * Safari 12.1~: plan-b
      * Safari 12.1~: unified-plan(if user enables)
+     * Safari 12.1.1~: unified-plan
      *
-     * So we need to convert server offer SDP if it in case.
+     * So we need to convert server offer SDP for plan-b Safari
      * We don't need to convert the answer back to Unified Plan because the server can handle Plan B.
      */
-    const browserInfo = util.detectBrowser();
-    // Means Chrome or Safari(plan-b)
-    if (!(browserInfo.name === 'firefox' || util.isUnifiedPlanSafari())) {
+    if (util.isPlanBSafari()) {
       offer = sdpUtil.unifiedToPlanB(offer);
     }
 

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -137,14 +137,6 @@ class SFURoom extends Room {
       }
     });
 
-    this._negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-      delete this.remoteStreams[stream.id];
-      delete this._msidMap[stream.id];
-      delete this._unknownStreams[stream.id];
-
-      this.emit(SFURoom.EVENTS.removeStream.key, stream);
-    });
-
     this._negotiator.on(Negotiator.EVENTS.negotiationNeeded.key, () => {
       // Renegotiate by requesting an offer then sending an answer when one is created.
       const offerRequestMessage = {
@@ -225,6 +217,8 @@ class SFURoom extends Room {
     for (const msid in this.remoteStreams) {
       if (this.remoteStreams[msid].peerId === src) {
         delete this.remoteStreams[msid];
+        delete this._msidMap[msid];
+        delete this._unknownStreams[msid];
       }
     }
 

--- a/src/shared/sdpUtil.js
+++ b/src/shared/sdpUtil.js
@@ -97,7 +97,7 @@ class SdpUtil {
    * @param {string} sdp - A SDP.
    * @return {string} A SDP which has `a=msid-semantic:WMS *`.
    */
-  pretendUnifiedPlan(sdp) {
+  ensureUnifiedPlan(sdp) {
     const delimiter = '\r\n';
     return sdp
       .split(delimiter)

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -102,20 +102,21 @@ function detectBrowser() {
  * It depends on user settings.
  * See https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/
  *
- * @return {boolean} Browser is Safari 12.1 or later and enables unified-plan OR NOT
+ * @return {boolean} Browser is plan-b Safari or NOT
  */
-function isUnifiedPlanSafari() {
-  const { name, major, minor } = detectBrowser();
+function isPlanBSafari() {
+  const { name } = detect();
 
-  if (
-    (name === 'safari' || name === 'ios') &&
-    (major >= 12 && minor >= 1) &&
-    RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
-  ) {
-    return true;
+  // safari for macOS, ios for iOS
+  if (!(name === 'safari' || name === 'ios')) {
+    return false;
+  }
+  // supports unified-plan
+  if (RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')) {
+    return false;
   }
 
-  return false;
+  return true;
 }
 
 export default {
@@ -127,5 +128,5 @@ export default {
   blobToArrayBuffer,
   isSecure,
   detectBrowser,
-  isUnifiedPlanSafari,
+  isPlanBSafari,
 };

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -185,45 +185,6 @@ describe('MediaConnection', () => {
 
       spy.restore();
     });
-
-    it("should set remoteStream to null on 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = remoteStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert.equal(mc.remoteStream, null);
-    });
-
-    it("should not change remoteStream on 'removeStream' being emitted if remoteStream is different", () => {
-      const origStream = {};
-      const removeStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-      mc.remoteStream = origStream;
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, removeStream);
-
-      assert.equal(mc.remoteStream, origStream);
-    });
-
-    it("should emit a 'removeStream' event upon 'removeStream' being emitted", () => {
-      const remoteStream = {};
-      const mc = new MediaConnection('remoteId', { stream: {} });
-
-      const spy = sinon.spy(mc, 'emit');
-
-      mc._negotiator.emit(Negotiator.EVENTS.removeStream.key, remoteStream);
-
-      assert(mc);
-      assert(spy.calledOnce);
-      assert(
-        spy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          remoteStream
-        ) === true
-      );
-
-      spy.restore();
-    });
   });
 
   describe('replaceStream', () => {

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -557,17 +557,11 @@ describe('MeshRoom', () => {
       );
     });
 
-    it('should handle stream and removeStream events if connection is a MediaConnection', () => {
+    it('should handle stream events if connection is a MediaConnection', () => {
       meshRoom._setupMessageHandlers({ on: onSpy, type: 'media' });
 
       assert(
         onSpy.calledWith(MediaConnection.EVENTS.stream.key, sinon.match.func)
-      );
-      assert(
-        onSpy.calledWith(
-          MediaConnection.EVENTS.removeStream.key,
-          sinon.match.func
-        )
       );
     });
 
@@ -655,20 +649,6 @@ describe('MeshRoom', () => {
           });
 
           mc.emit(MediaConnection.EVENTS.stream.key, stream);
-        });
-      });
-
-      describe('removeStream', () => {
-        it('should emit stream', done => {
-          const stream = {};
-
-          meshRoom.on(MeshRoom.EVENTS.removeStream.key, emittedStream => {
-            assert.equal(emittedStream, stream);
-
-            done();
-          });
-
-          mc.emit(MediaConnection.EVENTS.removeStream.key, stream);
         });
       });
     });

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -664,20 +664,14 @@ describe('Negotiator', () => {
       pcStub.restore();
     });
 
-    it('should set "plan-b" with pcConfig', () => {
-      const pcConf = { sdpSemantics: 'unified-plan' };
+    it('should use "unified-plan" with pcConfig', () => {
+      const pcConf = { sdpSemantics: 'plan-b' };
       negotiator._createPeerConnection(pcConf);
 
-      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
-      assert.equal(pcConf.sdpSemantics, 'plan-b');
-    });
+      assert.equal(pcConf.sdpSemantics, 'unified-plan');
 
-    it('should set "plan-b" with empty pcConfig', () => {
-      const pcConf = {};
-      negotiator._createPeerConnection(pcConf);
-
-      // TODO: When JS-SDK supports for 'unified-plan', this test should be changed.
-      assert.equal(pcConf.sdpSemantics, 'plan-b');
+      negotiator._createPeerConnection({});
+      assert.equal(pcConf.sdpSemantics, 'unified-plan');
     });
   });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -18,6 +18,7 @@ describe('Negotiator', () => {
     let newPcStub;
     let pcStub;
     let addTrackSpy;
+    let addTransceiverSpy;
     let createDCSpy;
     let negotiator;
     let handleOfferSpy;
@@ -27,9 +28,11 @@ describe('Negotiator', () => {
     beforeEach(() => {
       newPcStub = sinon.stub();
       addTrackSpy = sinon.spy();
+      addTransceiverSpy = sinon.spy();
       createDCSpy = sinon.spy();
       pcStub = {
         addTrack: addTrackSpy,
+        addTransceiver: addTransceiverSpy,
         createDataChannel: createDCSpy,
       };
       newPcStub.returns(pcStub);
@@ -45,6 +48,7 @@ describe('Negotiator', () => {
     afterEach(() => {
       newPcStub.reset();
       addTrackSpy.resetHistory();
+      addTransceiverSpy.resetHistory();
       createDCSpy.resetHistory();
       handleOfferSpy.resetHistory();
       setRemoteDescStub.restore();
@@ -86,20 +90,19 @@ describe('Negotiator', () => {
           assert.equal(handleOfferSpy.callCount, 0);
         });
 
-        it('should call _makeOfferSdp when stream does not exist', () => {
-          const makeOfferStub = sinon.stub(negotiator, '_makeOfferSdp');
-          makeOfferStub.returns(Promise.resolve('offer'));
-
+        it('should call pc.addTransceiver when stream does not exist', () => {
           const options = {
             type: 'media',
             originator: true,
             pcConfig: {},
           };
 
+          assert.equal(addTransceiverSpy.callCount, 0);
+
           negotiator.startConnection(options);
 
-          assert.equal(makeOfferStub.callCount, 1);
-          makeOfferStub.restore();
+          // video + audio = 2
+          assert.equal(addTransceiverSpy.callCount, 2);
         });
       });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -685,7 +685,6 @@ describe('Negotiator', () => {
       assert.equal(typeof pc.onicecandidate, 'function');
       assert.equal(typeof pc.oniceconnectionstatechange, 'function');
       assert.equal(typeof pc.onnegotiationneeded, 'function');
-      assert.equal(typeof pc.onremovestream, 'function');
       assert.equal(typeof pc.onsignalingstatechange, 'function');
     });
 
@@ -842,33 +841,6 @@ describe('Negotiator', () => {
               setTimeout(done);
             });
           });
-        });
-      });
-
-      describe('onremovestream', () => {
-        const evt = { stream: 'stream' };
-        let logSpy;
-
-        beforeEach(() => {
-          logSpy = sinon.spy(logger, 'log');
-        });
-
-        afterEach(() => {
-          logSpy.restore();
-        });
-
-        it('should log the event', () => {
-          pc.onremovestream(evt);
-          logSpy.calledWith('`removestream` triggered');
-        });
-
-        it("should emit 'removeStream'", done => {
-          negotiator.on(Negotiator.EVENTS.removeStream.key, stream => {
-            assert.equal(stream, evt.stream);
-            done();
-          });
-
-          pc.onremovestream(evt);
         });
       });
     });

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -191,7 +191,7 @@ describe('SFURoom', () => {
 
       describe('answerCreated', () => {
         it('should emit an answer message event', done => {
-          const answer = {};
+          const answer = { type: 'answer', sdp: 'v=0' };
           sfuRoom.on(SFURoom.MESSAGE_EVENTS.answer.key, answerMessage => {
             assert.equal(answerMessage.roomName, sfuRoomName);
             assert.equal(answerMessage.answer, answer);

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -105,7 +105,6 @@ describe('SFURoom', () => {
       sfuRoom._setupNegotiatorMessageHandlers();
 
       assert(onSpy.calledWith(Negotiator.EVENTS.addStream.key));
-      assert(onSpy.calledWith(Negotiator.EVENTS.removeStream.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceCandidate.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.answerCreated.key));
       assert(onSpy.calledWith(Negotiator.EVENTS.iceConnectionFailed.key));
@@ -173,50 +172,6 @@ describe('SFURoom', () => {
 
             assert.deepEqual(sfuRoom._unknownStreams, { [stream.id]: stream });
           });
-        });
-      });
-
-      describe('removeStream', () => {
-        const stream = { id: 'streamId', peerId: peerId };
-        const otherStream = { id: 'otherStream', peerId: remotePeerId };
-
-        it('should delete the stream from remoteStreams', () => {
-          sfuRoom.remoteStreams[stream.id] = stream;
-          sfuRoom.remoteStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom.remoteStreams[stream.id], undefined);
-          assert.equal(sfuRoom.remoteStreams[otherStream.id], otherStream);
-        });
-
-        it('should delete the stream from _msidMap', () => {
-          sfuRoom._msidMap[stream.id] = stream.peerId;
-          sfuRoom._msidMap[otherStream.id] = otherStream.peerId;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._msidMap[stream.id], undefined);
-          assert.equal(sfuRoom._msidMap[otherStream.id], otherStream.peerId);
-        });
-
-        it('should delete the stream from _unknownStreams', () => {
-          sfuRoom._unknownStreams[stream.id] = stream;
-          sfuRoom._unknownStreams[otherStream.id] = otherStream;
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
-
-          assert.equal(sfuRoom._unknownStreams[stream.id], undefined);
-          assert.equal(sfuRoom._unknownStreams[otherStream.id], otherStream);
-        });
-
-        it('should emit a removeStream event', done => {
-          sfuRoom.on(SFURoom.EVENTS.removeStream.key, removedStream => {
-            assert.equal(removedStream, stream);
-            done();
-          });
-
-          sfuRoom._negotiator.emit(Negotiator.EVENTS.removeStream.key, stream);
         });
       });
 


### PR DESCRIPTION
### Overview
- fix bug when `call()` without passing `stream`
  - ends up with error in unified-plan env
- use `unified-plan` only
  - we don't need `sdpSemantics` now, but to make sure...
  - Safari may be use `plan-b`(less than 12.1.1 / or manually set)
- use unified APIs
  - enable `recvonly` mode by `addTransceiver()`
  - no `createOffer(options)` anymore
- deprecated
  - `pc. onremovestream` event never fires
  - and `removeStream` events are also removed from `MediaConnection`, `MeshRoom` and `SFURoom`

### Checklist
<details>

```
- p2p-media: sendrecv -> sendrecv
  - [x] chrome -> firefox
  - [x] chrome -> safari(plan-b)
  - [x] chrome -> safari(unified-plan)
  - [x] firefox -> chrome
  - [x] firefox -> safari(plan-b)
  - [x] firefox -> safari(unified-plan)
  - [x] safari(plan-b) -> chrome
  - [x] safari(unified-plan) -> chrome
  - [x] safari(plan-b) -> firefox
  - [x] safari(unified-plan) -> firefox
- p2p-media: senderecv -> recvonly
  - [x] chrome -> firefox
  - [x] chrome -> safari(plan-b)
  - [x] chrome -> safari(unified-plan)
  - [x] firefox -> chrome
  - [x] firefox -> safari(plan-b)
  - [x] firefox -> safari(unified-plan)
  - [x] safari(plan-b) -> chrome
  - [x] safari(unified-plan) -> chrome
  - [x] safari(plan-b) -> firefox
  - [x] safari(unified-plan) -> firefox
- p2p-data
  - [x] chrome -> firefox
  - [x] chrome -> safari(plan-b)
  - [x] chrome -> safari(unified-plan)
  - [x] firefox -> chrome
  - [x] firefox -> safari(plan-b)
  - [x] firefox -> safari(unified-plan)  
  - [x] safari(plan-b) -> chrome
  - [x] safari(unified-plan) -> chrome
  - [x] safari(plan-b) -> firefox
  - [x] safari(unified-plan) -> firefox
- mesh: sendrecv * N
  - [x] chrome
  - [x] firefox
  - [x] safari(plan-b)
  - [x] safari(unified-plan)
- mesh: sendrecv * 1 + recvonly * N
  - [x] chrome
  - [x] firefox
  - [x] safari(plan-b)
  - [x] safari(unified-plan)
- sfu: sendrecv * N
  - [x] chrome
  - [x] firefox
  - [x] safari(plan-b)
  - [x] safari(unified-plan)
- sfu: sendrecv * 1 + recvonly * N
  - [x] chrome
  - [x] firefox
  - [x] safari(plan-b)
  - [x] safari(unified-plan)
```

</details>