### PR TITLE
display dispatcher error in detail

### DIFF
--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -170,7 +170,7 @@ class Socket extends EventEmitter {
       http.timeout = config.DISPATCHER_TIMEOUT;
       http.open('GET', this._dispatcherUrl, true);
       /* istanbul ignore next */
-      http.onerror = (evt) => {
+      http.onerror = () => {
         reject(new Error('There was a problem with the request for the dispatcher. Check your request and network connections.'));
       };
 

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -185,7 +185,7 @@ class Socket extends EventEmitter {
       http.ontimeout = () => {
         reject(
           new Error(
-            'The request for the dispatcher timed out. Check your firewall, network speed, Skyway failure information'
+            'The request for the dispatcher timed out. Check your firewall, network speed, SkyWay failure information'
           )
         );
       };
@@ -195,6 +195,7 @@ class Socket extends EventEmitter {
           reject(
             new Error('Connection failed. Invalid response: ' + http.status)
           );
+          return;
           //http.status = 200
         } else {
           //fetch valid JSON

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -196,8 +196,6 @@ class Socket extends EventEmitter {
           );
           return;
         }
-        //when http.status === 200
-        //when fetch valid JSON
         try {
           const res = JSON.parse(http.responseText);
           if (res && res.domain) {
@@ -209,7 +207,6 @@ class Socket extends EventEmitter {
               'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
             )
           );
-          //when fetch invalid JSON
         } catch (err) {
           reject(
             new Error(

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -171,7 +171,11 @@ class Socket extends EventEmitter {
       http.open('GET', this._dispatcherUrl, true);
       /* istanbul ignore next */
       http.onerror = () => {
-        reject(new Error('There was a problem with the request for the dispatcher. Check your request and network connections.'));
+        reject(
+          new Error(
+            'There was a problem with the request for the dispatcher. Check your request and network connections.'
+          )
+        );
       };
 
       http.onabort = () => {
@@ -179,34 +183,36 @@ class Socket extends EventEmitter {
       };
 
       http.ontimeout = () => {
-        reject(new Error('The request for the dispatcher timed out. Check your firewall, network speed, Skyway failure information'));
+        reject(
+          new Error(
+            'The request for the dispatcher timed out. Check your firewall, network speed, Skyway failure information'
+          )
+        );
       };
       http.onload = () => {
         let res = null;
-        if (http.status !== 200){
+        if (http.status !== 200) {
           reject(
-            new Error(
-              'Connection failed. Invalid response: ' + http.status
-            )
+            new Error('Connection failed. Invalid response: ' + http.status)
           );
-        //http.status = 200
-        }else{
+          //http.status = 200
+        } else {
           //fetch valid JSON
-          try{
+          try {
             res = JSON.parse(http.responseText);
             if (res && res.domain) {
               resolve({ host: res.domain, port: 443, secure: true });
-                return;
-            }else{
+              return;
+            } else {
               reject(
                 new Error(
                   'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
                 )
-              )
+              );
               return;
             }
-          //fetch invalid JSON
-          }catch(err){
+            //fetch invalid JSON
+          } catch (err) {
             reject(
               new Error(
                 'The dispatcher server returned an invalid JSON response.'
@@ -214,7 +220,7 @@ class Socket extends EventEmitter {
             );
           }
         }
-      }
+      };
       http.send(null);
     });
   }

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -190,14 +190,14 @@ class Socket extends EventEmitter {
         );
       };
       http.onload = () => {
-        let res = null;
+        const res = null;
         if (http.status !== 200) {
           reject(
             new Error('Connection failed. Invalid response: ' + http.status)
           );
           return;
         }
-        //http.status = 200
+        //when http.status === 200
         //fetch valid JSON
         try {
           res = JSON.parse(http.responseText);
@@ -210,7 +210,6 @@ class Socket extends EventEmitter {
               'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
             )
           );
-          return;
           //fetch invalid JSON
         } catch (err) {
           reject(
@@ -218,7 +217,6 @@ class Socket extends EventEmitter {
               'The dispatcher server returned an invalid JSON response.'
             )
           );
-          return;
         }
       };
       http.send(null);

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -219,6 +219,7 @@ class Socket extends EventEmitter {
                 'The dispatcher server returned an invalid JSON response.'
               )
             );
+            return;
           }
         }
       };

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -196,31 +196,29 @@ class Socket extends EventEmitter {
             new Error('Connection failed. Invalid response: ' + http.status)
           );
           return;
-          //http.status = 200
-        } else {
-          //fetch valid JSON
-          try {
-            res = JSON.parse(http.responseText);
-            if (res && res.domain) {
-              resolve({ host: res.domain, port: 443, secure: true });
-              return;
-            } else {
-              reject(
-                new Error(
-                  'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
-                )
-              );
-              return;
-            }
-            //fetch invalid JSON
-          } catch (err) {
-            reject(
-              new Error(
-                'The dispatcher server returned an invalid JSON response.'
-              )
-            );
+        }
+        //http.status = 200
+        //fetch valid JSON
+        try {
+          res = JSON.parse(http.responseText);
+          if (res && res.domain) {
+            resolve({ host: res.domain, port: 443, secure: true });
             return;
           }
+          reject(
+            new Error(
+              'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
+            )
+          );
+          return;
+          //fetch invalid JSON
+        } catch (err) {
+          reject(
+            new Error(
+              'The dispatcher server returned an invalid JSON response.'
+            )
+          );
+          return;
         }
       };
       http.send(null);

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -190,7 +190,6 @@ class Socket extends EventEmitter {
         );
       };
       http.onload = () => {
-        const res = null;
         if (http.status !== 200) {
           reject(
             new Error('Connection failed. Invalid response: ' + http.status)
@@ -198,9 +197,9 @@ class Socket extends EventEmitter {
           return;
         }
         //when http.status === 200
-        //fetch valid JSON
+        //when fetch valid JSON
         try {
-          res = JSON.parse(http.responseText);
+          const res = JSON.parse(http.responseText);
           if (res && res.domain) {
             resolve({ host: res.domain, port: 443, secure: true });
             return;
@@ -210,7 +209,7 @@ class Socket extends EventEmitter {
               'The dispatcher server returned an invalid JSON response. have no signaling server domain in JSON.'
             )
           );
-          //fetch invalid JSON
+          //when fetch invalid JSON
         } catch (err) {
           reject(
             new Error(

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -513,8 +513,7 @@ describe('Socket', () => {
         const result = {
           error: {
             code: 500,
-            message:
-              'Connection failed. Invalid response: 500',
+            message: 'Connection failed. Invalid response: 500',
           },
         };
 
@@ -539,8 +538,12 @@ describe('Socket', () => {
 
     describe('when status code from dispatcher is 404', () => {
       it('should reject', done => {
-        const result = { error: { code: 404, message: 'Connection failed. Invalid response: 404' } };
-
+        const result = {
+          error: {
+            code: 404,
+            message: 'Connection failed. Invalid response: 404',
+          },
+        };
         socket
           ._getSignalingServer()
           .then(() => {
@@ -549,7 +552,10 @@ describe('Socket', () => {
           })
           .catch(err => {
             assert(err);
-            assert.equal(err.message, 'Connection failed. Invalid response: 404');
+            assert.equal(
+              err.message,
+              'Connection failed. Invalid response: 404'
+            );
             done();
           });
 
@@ -559,7 +565,12 @@ describe('Socket', () => {
 
     describe('when status code from dispatcher is 405', () => {
       it('should reject', done => {
-        const result = { error: { code: 405, message: 'Connection failed. Invalid response: 405' } };
+        const result = {
+          error: {
+            code: 405,
+            message: 'Connection failed. Invalid response: 405',
+          },
+        };
 
         socket
           ._getSignalingServer()
@@ -569,7 +580,10 @@ describe('Socket', () => {
           })
           .catch(err => {
             assert(err);
-            assert.equal(err.message, 'Connection failed. Invalid response: 405');
+            assert.equal(
+              err.message,
+              'Connection failed. Invalid response: 405'
+            );
             done();
           });
 

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -514,7 +514,7 @@ describe('Socket', () => {
           error: {
             code: 500,
             message:
-              'There was a problem with the server. Please wait a while and try again.',
+              'Connection failed. Invalid response: 500',
           },
         };
 
@@ -528,7 +528,7 @@ describe('Socket', () => {
             assert(err);
             assert.equal(
               err.message,
-              'There was a problem with the server. Please wait a while and try again.'
+              'Connection failed. Invalid response: 500'
             );
             done();
           });
@@ -539,7 +539,7 @@ describe('Socket', () => {
 
     describe('when status code from dispatcher is 404', () => {
       it('should reject', done => {
-        const result = { error: { code: 404, message: 'Not Found.' } };
+        const result = { error: { code: 404, message: 'Connection failed. Invalid response: 404' } };
 
         socket
           ._getSignalingServer()
@@ -549,7 +549,7 @@ describe('Socket', () => {
           })
           .catch(err => {
             assert(err);
-            assert.equal(err.message, 'Not Found.');
+            assert.equal(err.message, 'Connection failed. Invalid response: 404');
             done();
           });
 
@@ -559,7 +559,7 @@ describe('Socket', () => {
 
     describe('when status code from dispatcher is 405', () => {
       it('should reject', done => {
-        const result = { error: { code: 405, message: 'Method Not Allowed.' } };
+        const result = { error: { code: 405, message: 'Connection failed. Invalid response: 405' } };
 
         socket
           ._getSignalingServer()
@@ -569,7 +569,7 @@ describe('Socket', () => {
           })
           .catch(err => {
             assert(err);
-            assert.equal(err.message, 'Method Not Allowed.');
+            assert.equal(err.message, 'Connection failed. Invalid response: 405');
             done();
           });
 


### PR DESCRIPTION
This PR can make it easily to find the cause in dispatcher error.

- Replace `http.onreadystate` with  `http.onload` to fix double reject error. It can process as expected.
- Use `http.status`. It can display error in detail. 


