### PR TITLE
Firefox 68~ indicates `end-of-candidates` by empty string and null candidate

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -10,7 +10,6 @@ const NegotiatorEvents = new Enum([
   'offerCreated',
   'answerCreated',
   'iceCandidate',
-  'iceCandidatesComplete',
   'iceConnectionFailed',
   'negotiationNeeded',
   'error',
@@ -272,10 +271,6 @@ class Negotiator extends EventEmitter {
        */
       if (!evt.candidate || evt.candidate.candidate === '') {
         logger.log('ICE candidates gathering complete');
-        this.emit(
-          Negotiator.EVENTS.iceCandidatesComplete.key,
-          pc.localDescription
-        );
         return;
       }
 
@@ -577,13 +572,6 @@ class Negotiator extends EventEmitter {
    *
    * @event Negotiator#iceCandidate
    * @type {RTCIceCandidate}
-   */
-
-  /**
-   * Ice Candidate collection finished. Emits localDescription.
-   *
-   * @event Negotiator#iceCandidatesComplete
-   * @type {RTCSessionDescription}
    */
 
   /**

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -260,18 +260,27 @@ class Negotiator extends EventEmitter {
     };
 
     pc.onicecandidate = evt => {
-      const candidate = evt.candidate;
-      if (candidate) {
-        logger.log('Generated ICE candidate for:', candidate);
-        this.emit(Negotiator.EVENTS.iceCandidate.key, candidate);
-      } else {
+      /**
+       * Signals end-of-candidates by
+       *
+       * Firefox 68~
+       * evt = { candidate: RTCIceCandidate({ candidate: "" }) and
+       * evt = { candidate: null }
+       *
+       * Firefox ~67, Chrome, Safari
+       * evt = { candidate: null }
+       */
+      if (!evt.candidate || evt.candidate.candidate === '') {
         logger.log('ICE candidates gathering complete');
-
         this.emit(
           Negotiator.EVENTS.iceCandidatesComplete.key,
           pc.localDescription
         );
+        return;
       }
+
+      logger.log('Generated ICE candidate for:', evt.candidate);
+      this.emit(Negotiator.EVENTS.iceCandidate.key, evt.candidate);
     };
 
     pc.oniceconnectionstatechange = () => {

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -715,43 +715,23 @@ describe('Negotiator', () => {
 
       describe('onicecandidate', () => {
         it("should emit 'iceCandidate' with ice candidate", done => {
-          const ev = { candidate: 'candidate' };
+          const ev = { candidate: { candidate: 'candidate' } };
+
           negotiator.on(Negotiator.EVENTS.iceCandidate.key, candidate => {
             assert(candidate, ev.candidate);
             done();
           });
-
           pc.onicecandidate(ev);
         });
 
-        it("should emit 'iceCandidatesComplete' when out of candidates", done => {
-          const ev = { candidate: null };
-          negotiator.on(Negotiator.EVENTS.iceCandidatesComplete.key, () =>
-            done()
-          );
-
-          pc.onicecandidate(ev);
-        });
-
-        it("should emit 'iceCandidatesComplete' when out of candidates(empty string)", done => {
-          const ev = { candidate: '' };
-          negotiator.on(Negotiator.EVENTS.iceCandidatesComplete.key, () =>
-            done()
-          );
-
-          pc.onicecandidate(ev);
-        });
-
-        it("should not emit 'iceCandidate' when out of candidates", done => {
-          const ev = {};
+        it("should not emit 'iceCandidate' when out of candidates", () => {
           negotiator.on(Negotiator.EVENTS.iceCandidate.key, () => {
             assert.fail('Should not emit iceCandidate event');
           });
 
-          pc.onicecandidate(ev);
-
-          // let other async events run before finishing
-          setTimeout(done);
+          [{}, { candidate: null }, { candidate: { candidate: '' } }].forEach(
+            ev => pc.onicecandidate(ev)
+          );
         });
       });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -733,6 +733,15 @@ describe('Negotiator', () => {
           pc.onicecandidate(ev);
         });
 
+        it("should emit 'iceCandidatesComplete' when out of candidates(empty string)", done => {
+          const ev = { candidate: '' };
+          negotiator.on(Negotiator.EVENTS.iceCandidatesComplete.key, () =>
+            done()
+          );
+
+          pc.onicecandidate(ev);
+        });
+
         it("should not emit 'iceCandidate' when out of candidates", done => {
           const ev = {};
           negotiator.on(Negotiator.EVENTS.iceCandidate.key, () => {


### PR DESCRIPTION
Do not emit `iceCandidate` event for `""` candidate, `null` either. 

And remove `iceCandidatesComplete` event which is unused...