### PR TITLE
Allow PR from dependabot.

### DIFF
--- a/scripts/ensure-branch/index.js
+++ b/scripts/ensure-branch/index.js
@@ -47,6 +47,7 @@ const fetchBaseBranch = require('./fetch-base-branch');
     case baseBranch === 'master' && currentBranch === 'staging':
     case baseBranch === 'staging' && currentBranch.startsWith('ops/'):
     case baseBranch === 'staging' && currentBranch.startsWith('dev/'):
+    case baseBranch === 'staging' && currentBranch.startsWith('dependabot/'):
       console.log('Branch names are valid ;D');
       break;
     default:


### PR DESCRIPTION
We need to add dependabot pattern to naming rule since we're ensuring the branch name in status checks.