### PR TITLE
Handle video|audio only stream

### DIFF
--- a/src/peer/mediaConnection.js
+++ b/src/peer/mediaConnection.js
@@ -82,8 +82,6 @@ class MediaConnection extends Connection {
    * @param {number} [options.audioBandwidth] - A max audio bandwidth(kbps)
    * @param {string} [options.videoCodec] - A video codec like 'H264'
    * @param {string} [options.audioCodec] - A video codec like 'PCMU'
-   * @param {boolean} [options.videoReceiveEnabled] - A flag to set video recvonly
-   * @param {boolean} [options.audioReceiveEnabled] - A flag to set audio recvonly
    */
   answer(stream, options = {}) {
     if (this.localStream) {
@@ -106,8 +104,6 @@ class MediaConnection extends Connection {
       videoBandwidth: options.videoBandwidth,
       videoCodec: options.videoCodec,
       audioCodec: options.audioCodec,
-      videoReceiveEnabled: options.videoReceiveEnabled,
-      audioReceiveEnabled: options.audioReceiveEnabled,
     });
     this._pcAvailable = true;
 

--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -67,13 +67,13 @@ class Negotiator extends EventEmitter {
     if (this._type === 'media') {
       // video+audio or video only or audio only stream passed
       if (options.stream) {
-        const [vTrack] = options.stream.getVideoTracks();
-        const [aTrack] = options.stream.getAudioTracks();
+        const vTracks = options.stream.getVideoTracks();
+        const aTracks = options.stream.getAudioTracks();
         const recvonlyState = this._getReceiveOnlyState(options);
 
         // create m= section w/ direction sendrecv
-        if (vTrack) {
-          this._pc.addTrack(vTrack, options.stream);
+        if (vTracks.length > 0) {
+          vTracks.forEach(track => this._pc.addTrack(track, options.stream));
         }
         // create m= section w/ direction recvonly or omit whole m= section
         else {
@@ -81,8 +81,8 @@ class Negotiator extends EventEmitter {
             this._pc.addTransceiver('video', { direction: 'recvonly' });
         }
 
-        if (aTrack) {
-          this._pc.addTrack(aTrack, options.stream);
+        if (aTracks.length > 0) {
+          aTracks.forEach(track => this._pc.addTrack(track, options.stream));
         } else {
           recvonlyState.audio &&
             this._pc.addTransceiver('audio', { direction: 'recvonly' });

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -24,6 +24,12 @@ describe('Negotiator', () => {
     let handleOfferSpy;
     let createPCStub;
     let setRemoteDescStub;
+    const audioVideoStream = new MediaStream();
+
+    before(() => {
+      sinon.stub(audioVideoStream, 'getVideoTracks').returns([{}]);
+      sinon.stub(audioVideoStream, 'getAudioTracks').returns([{}]);
+    });
 
     beforeEach(() => {
       newPcStub = sinon.stub();
@@ -72,11 +78,7 @@ describe('Negotiator', () => {
         it('should call pc.addTrack when stream exists', () => {
           const options = {
             type: 'media',
-            stream: {
-              getTracks() {
-                return [{}];
-              },
-            },
+            stream: audioVideoStream,
             originator: true,
             pcConfig: {},
           };
@@ -86,7 +88,7 @@ describe('Negotiator', () => {
 
           negotiator.startConnection(options);
 
-          assert.equal(addTrackSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 2);
           assert.equal(handleOfferSpy.callCount, 0);
         });
 
@@ -110,11 +112,7 @@ describe('Negotiator', () => {
         it('should call pc.addTrack and handleOffer', () => {
           const options = {
             type: 'media',
-            stream: {
-              getTracks() {
-                return [{}];
-              },
-            },
+            stream: audioVideoStream,
             originator: false,
             pcConfig: {},
             offer: {},
@@ -125,7 +123,7 @@ describe('Negotiator', () => {
 
           negotiator.startConnection(options);
 
-          assert.equal(addTrackSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 2);
           assert.equal(handleOfferSpy.callCount, 1);
           assert(handleOfferSpy.calledWith(options.offer));
         });
@@ -135,11 +133,7 @@ describe('Negotiator', () => {
         it('should call pc.addTrack and handleOffer', () => {
           const options = {
             type: 'media',
-            stream: {
-              getTracks() {
-                return [{}];
-              },
-            },
+            stream: audioVideoStream,
             pcConfig: {},
             offer: {},
           };
@@ -149,7 +143,7 @@ describe('Negotiator', () => {
 
           negotiator.startConnection(options);
 
-          assert.equal(addTrackSpy.callCount, 1);
+          assert.equal(addTrackSpy.callCount, 2);
           assert.equal(handleOfferSpy.callCount, 1);
           assert(handleOfferSpy.calledWith(options.offer));
         });


### PR DESCRIPTION
```js
peer.call(id, audioOnlyStream);
```

should generate SDP includes,

- video: `recvonly`
- audio: `sendrecv`

but now, it does not emit its video `m=` section...

At the same time, it should be able to omit video `m=` section by,

```js
peer.call(id, audioOnlyStream, { videoReceiveEnabled: false });
```

notes:

```js
peer.call(id, audioOnlyStream);
peer.call(id, audioOnlyStream, { videoReceiveEnabled: true });
```

These lines have a same effect.