### PR TITLE
Fix SFURoom#members

### DIFF
--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -176,12 +176,16 @@ class SFURoom extends Room {
    * @param {Object} joinMessage - Message object.
    * @param {string} joinMessage.src - The peerId of the peer that joined.
    * @param {string} joinMessage.roomName - The name of the joined room.
+   * @param {Array} joinMessage.roomMembers - Array of peerId string.
    */
   handleJoin(joinMessage) {
-    const src = joinMessage.src;
+    const { src, roomMembers } = joinMessage;
 
     if (src === this._peerId) {
       this._open = true;
+
+      // init w/ members already in room(ignore myself)
+      this.members = roomMembers.filter(peerId => peerId !== src);
 
       this.call(this._localStream);
       this.emit(SFURoom.EVENTS.open.key);

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -234,6 +234,7 @@ describe('SFURoom', () => {
     describe('when message src is your peerId', () => {
       const joinMessage = {
         src: peerId,
+        roomMembers: [peerId],
       };
 
       it('should emit an open event', done => {
@@ -284,6 +285,7 @@ describe('SFURoom', () => {
     describe('when message src is not your peerId', () => {
       const joinMessage = {
         src: remotePeerId,
+        roomMembers: [peerId, remotePeerId],
       };
 
       it('should add user to members', () => {


### PR DESCRIPTION
- for SFU room only
  - for Mesh room `connections` is in charge
- init `members` array on joining room
  - also sync on leaving may be better, but if so, it requires many changes...