### PR TITLE
Fix the timing issue about mesh room.

### DIFF
--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -160,6 +160,11 @@ class MeshRoom extends Room {
     }
 
     if (offerMessage.connectionType === 'media') {
+      if (this._hasConnection(offerMessage.src)) {
+        // When two or more users join at the same time, they send each other an offer.
+        // In order to prevent two connections between peerA and peerB, only the one with a small ID will be processed.
+        if (this._peerId > offerMessage.src) return;
+      }
       connection = new MediaConnection(offerMessage.src, {
         connectionId: connectionId,
         payload: offerMessage,
@@ -312,6 +317,9 @@ class MeshRoom extends Room {
       .filter(peerId => {
         return peerId !== this._peerId;
       })
+      .filter(peerId => {
+        return !this._hasConnection(peerId);
+      })
       .forEach(peerId => {
         let connection;
 
@@ -360,6 +368,16 @@ class MeshRoom extends Room {
       return conn[0];
     }
     return null;
+  }
+
+  /**
+   * Return whether peer has already made a connection to 'peerId' or not
+   * @param {string} peerId - User's PeerId.
+   * @return {boolean} - Whether peer has already made a connection to 'peerId' or not
+   * @private
+   */
+  _hasConnection(peerId) {
+    return this.connections[peerId] && this.connections[peerId].length > 0;
   }
 
   /**

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -274,6 +274,18 @@ describe('MeshRoom', () => {
         assert.equal(answerSpy.callCount, 1);
         assert(answerSpy.calledWith(meshRoom._localStream));
       });
+
+      it('should not create MediaConnection when has a connection with peer and peerId is larger', () => {
+        const smallPeerId = 'aaaa';
+        meshRoom._addConnection(smallPeerId, { id: 'connId1' });
+        meshRoom.handleOffer({
+          connectionId: 'connId2',
+          connectionType: 'media',
+          src: smallPeerId,
+        });
+
+        assert(mcStub.neverCalledWith(smallPeerId));
+      });
     });
 
     // TODO: when dataConnection messages is implemented?
@@ -503,6 +515,13 @@ describe('MeshRoom', () => {
         meshRoom._makeConnections(peerIds, 'media', options);
 
         assert(mcStub.neverCalledWith(peerId));
+      });
+
+      it('should not create MediaConnection when has a connection with peer', () => {
+        meshRoom._addConnection(remotePeerId1, { id: 'connId1' });
+        meshRoom._makeConnections([remotePeerId1], 'media', options);
+
+        assert(mcStub.neverCalledWith(remotePeerId1));
       });
     });
   });

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -275,16 +275,30 @@ describe('MeshRoom', () => {
         assert(answerSpy.calledWith(meshRoom._localStream));
       });
 
-      it('should not create MediaConnection when has a connection with peer and peerId is larger', () => {
-        const smallPeerId = 'aaaa';
-        meshRoom._addConnection(smallPeerId, { id: 'connId1' });
-        meshRoom.handleOffer({
-          connectionId: 'connId2',
-          connectionType: 'media',
-          src: smallPeerId,
-        });
+      it('should not create MediaConnection when has a connection with the peer and self peerId is larger', () => {
+        const testItems = [
+          { src: 'bbbbbbb', self: 'bbbbbbbb' },
+          { src: 'baaaaaa', self: 'bbbbbbb' },
+          { src: 'aaaaaaa', self: 'baaaaaa' },
+          { src: '_______', self: 'aaaaaaa' },
+          { src: 'AAAAAAA', self: '_______' },
+          { src: '1234567', self: 'AAAAAAA' },
+          { src: '-------', self: '1234567' },
+          { src: '-      ', self: '-------' },
+        ];
 
-        assert(mcStub.neverCalledWith(smallPeerId));
+        for (const testItem of testItems) {
+          meshRoom._peerId = testItem.self;
+          meshRoom._addConnection(testItem.src, {
+            id: `connId1_${testItem.src}`,
+          });
+          meshRoom.handleOffer({
+            connectionId: `connId2_${testItem.src}`,
+            connectionType: 'media',
+            src: testItem.src,
+          });
+          assert(mcStub.neverCalledWith(testItem.src));
+        }
       });
     });
 

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -277,27 +277,27 @@ describe('MeshRoom', () => {
 
       it('should not create MediaConnection when has a connection with the peer and self peerId is larger', () => {
         const testItems = [
-          { src: 'bbbbbbb', self: 'bbbbbbbb' },
-          { src: 'baaaaaa', self: 'bbbbbbb' },
-          { src: 'aaaaaaa', self: 'baaaaaa' },
-          { src: '_______', self: 'aaaaaaa' },
-          { src: 'AAAAAAA', self: '_______' },
-          { src: '1234567', self: 'AAAAAAA' },
-          { src: '-------', self: '1234567' },
-          { src: '-      ', self: '-------' },
+          { remotePeerId: 'bbbbbbb', localPeerId: 'bbbbbbbb' },
+          { remotePeerId: 'baaaaaa', localPeerId: 'bbbbbbb' },
+          { remotePeerId: 'aaaaaaa', localPeerId: 'baaaaaa' },
+          { remotePeerId: '_______', localPeerId: 'aaaaaaa' },
+          { remotePeerId: 'AAAAAAA', localPeerId: '_______' },
+          { remotePeerId: '1234567', localPeerId: 'AAAAAAA' },
+          { remotePeerId: '-------', localPeerId: '1234567' },
+          { remotePeerId: '-      ', localPeerId: '-------' },
         ];
 
         for (const testItem of testItems) {
-          meshRoom._peerId = testItem.self;
-          meshRoom._addConnection(testItem.src, {
-            id: `connId1_${testItem.src}`,
+          meshRoom._peerId = testItem.localPeerId;
+          meshRoom._addConnection(testItem.remotePeerId, {
+            id: `connId1_${testItem.remotePeerId}`,
           });
           meshRoom.handleOffer({
-            connectionId: `connId2_${testItem.src}`,
+            connectionId: `connId2_${testItem.remotePeerId}`,
             connectionType: 'media',
-            src: testItem.src,
+            src: testItem.remotePeerId,
           });
-          assert(mcStub.neverCalledWith(testItem.src));
+          assert(mcStub.neverCalledWith(testItem.remotePeerId));
         }
       });
     });


### PR DESCRIPTION
When two or more users join to a mesh room at the same time, they send each other an offer.
In order to prevent two connections between peerA and peerB, only the one with a small ID will be processed.
