### PR TITLE
Limit the size of data to send by using SFU/MeshRoom.send().

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "query-string": "^6.8.2",
     "sdp-interop": "^0.1.13",
     "sdp-transform": "^2.11.0",
-    "socket.io-client": "^2.2.0"
+    "socket.io-client": "^2.2.0",
+    "socket.io-parser": "~3.3.0"
   }
 }

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -245,6 +245,9 @@ class MeshRoom extends Room {
    * @param {*} data - The data to send.
    */
   send(data) {
+    if (this.isOverLimits(data)) {
+      throw new Error('The size of data to send must be less than 20 MB');
+    }
     const message = {
       roomName: this.name,
       data: data,

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -254,7 +254,7 @@ class MeshRoom extends Room {
       roomName: this.name,
       data: data,
     };
-    if (this.validateDataSize(data)) {
+    if (this.validateSendDataSize(data)) {
       this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
     }
   }

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -250,14 +250,13 @@ class MeshRoom extends Room {
    * @param {*} data - The data to send.
    */
   send(data) {
-    if (this.isOverLimits(data)) {
-      throw new Error('The size of data to send must be less than 20 MB');
-    }
     const message = {
       roomName: this.name,
       data: data,
     };
-    this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
+    if (this.validateDataSize(data)) {
+      this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
+    }
   }
 
   /**

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 import Enum from 'enum';
 import parser from 'socket.io-parser';
 import hasBin from 'has-binary2';
+import config from '../shared/config';
 
 const Events = [
   'stream',
@@ -63,27 +64,27 @@ class Room extends EventEmitter {
   }
 
   /**
-   * Check whether the size of data to send is over the limits or not.
-   * @param {object} data - The data to check.
+   * Validate whether the size of data to send is over the limits or not.
+   * @param {object} data - The data to Validate.
    */
-  isOverLimits(data) {
+  validateDataSize(data) {
     const isBin = hasBin([data]);
     const packet = {
       type: isBin ? parser.BINARY_EVENT : parser.EVENT,
       data: [data],
     };
     const encoder = new parser.Encoder();
-    let dataLength;
+    let dataSize;
     encoder.encode(packet, encodedPackets => {
-      dataLength = isBin
+      dataSize = isBin
         ? encodedPackets[1].byteLength
         : encodedPackets[0].length;
     });
-    const limits = 20 * 10 ** 6; // 20 MB
-    if (dataLength > limits) {
-      return true;
+    const maxDataSize = config.maxDataSize;
+    if (dataSize > maxDataSize) {
+      throw new Error('The size of data to send must be less than 20 MB');
     }
-    return false;
+    return true;
   }
 
   /**

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -67,7 +67,7 @@ class Room extends EventEmitter {
    * Validate whether the size of data to send is over the limits or not.
    * @param {object} data - The data to Validate.
    */
-  validateDataSize(data) {
+  validateSendDataSize(data) {
     const isBin = hasBin([data]);
     const packet = {
       type: isBin ? parser.BINARY_EVENT : parser.EVENT,

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -240,7 +240,7 @@ class SFURoom extends Room {
       roomName: this.name,
       data: data,
     };
-    if (this.validateDataSize(data)) {
+    if (this.validateSendDataSize(data)) {
       this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
     }
   }

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -240,10 +240,9 @@ class SFURoom extends Room {
       roomName: this.name,
       data: data,
     };
-    if (this.isOverLimits(data)) {
-      throw new Error('The size of data to send must be less than 20 MB');
+    if (this.validateDataSize(data)) {
+      this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
     }
-    this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
   }
 
   /**

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -236,11 +236,13 @@ class SFURoom extends Room {
     if (!this._open) {
       return;
     }
-
     const message = {
       roomName: this.name,
       data: data,
     };
+    if (this.isOverLimits(data)) {
+      throw new Error('The size of data to send must be less than 20 MB');
+    }
     this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
   }
 

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -49,6 +49,9 @@ const MESSAGE_TYPES = {
 // The actual chunk size is adjusted in dataChannel to accomodate metaData
 const maxChunkSize = 16300;
 
+// The maximum size of data that can be sent at one time by using Room.send() is 20 MB
+const maxDataSize = 20 * 1024 * 1024;
+
 // Number of reconnection attempts to the same server before giving up
 const reconnectionAttempts = 2;
 
@@ -80,6 +83,7 @@ export default {
   TURN_PORT,
   MESSAGE_TYPES,
   maxChunkSize,
+  maxDataSize,
   reconnectionAttempts,
   numberServersToTry,
   sendInterval,

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -362,14 +362,12 @@ describe('MeshRoom', () => {
 
   describe('send', () => {
     const randomString = size => {
-      let str = '';
       const s =
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      const iMax = Math.floor(size / 64);
-      for (let i = 0; i < iMax; i++) {
-        str += s;
-      }
-      return str;
+      return (
+        s.repeat(Math.floor(size / s.length)) +
+        s.substring(s.length - (size % s.length))
+      );
     };
     const sizeOver = 21 * 1024 * 1024;
     const sizeUnder = 19 * 1024 * 1024;

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -335,6 +335,18 @@ describe('MeshRoom', () => {
   });
 
   describe('send', () => {
+    const randomString = size => {
+      let str = '';
+      const s =
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+      for (let i = 0; i < size; i++) {
+        str += s[Math.floor(Math.random() * s.length)];
+      }
+      return str;
+    };
+    const size = 21 * 10 ** 6;
+    const dummyLargeData = randomString(size);
+
     it('should emit a broadcast event', done => {
       const data = 'foobar';
 
@@ -344,6 +356,32 @@ describe('MeshRoom', () => {
       });
 
       meshRoom.send(data);
+    });
+
+    it('should throw an error when the size of data to send is greater than 20 MB', done => {
+      const message = 'The size of data to send must be less than 20 MB';
+
+      try {
+        meshRoom.send(dummyLargeData);
+      } catch (err) {
+        assert.strictEqual(err.message, message);
+        done();
+      }
+    });
+
+    it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+      meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+        assert.fail('Should not have emitted a broadcast event');
+      });
+
+      try {
+        meshRoom.send(dummyLargeData);
+      } catch (err) {
+        // empty
+      }
+
+      // let other async events run
+      setTimeout(done);
     });
   });
 

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -364,14 +364,13 @@ describe('MeshRoom', () => {
     const randomString = size => {
       let str = '';
       const s =
-        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
       for (let i = 0; i < size; i++) {
         str += s[Math.floor(Math.random() * s.length)];
       }
       return str;
     };
-    const size = 21 * 10 ** 6;
-    const dummyLargeData = randomString(size);
+    const dummyDataSize = 21 * 1024 * 1024;
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -384,30 +383,94 @@ describe('MeshRoom', () => {
       meshRoom.send(data);
     });
 
-    it('should throw an error when the size of data to send is greater than 20 MB', done => {
-      const message = 'The size of data to send must be less than 20 MB';
+    describe('when the data type is string', () => {
+      const dummyString = randomString(dummyDataSize);
 
-      try {
-        meshRoom.send(dummyLargeData);
-      } catch (err) {
-        assert.strictEqual(err.message, message);
-        done();
-      }
-    });
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const message = 'The size of data to send must be less than 20 MB';
 
-    it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
-      meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
-        assert.fail('Should not have emitted a broadcast event');
+        try {
+          meshRoom.send(dummyString);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
       });
 
-      try {
-        meshRoom.send(dummyLargeData);
-      } catch (err) {
-        // empty
-      }
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
 
-      // let other async events run
-      setTimeout(done);
+        try {
+          meshRoom.send(dummyString);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
+    });
+
+    describe('when the data type is binary (ArrayBuffer)', () => {
+      const dummyArrayBuffer = new ArrayBuffer(dummyDataSize);
+
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const message = 'The size of data to send must be less than 20 MB';
+
+        try {
+          meshRoom.send(dummyArrayBuffer);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
+      });
+
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
+
+        try {
+          meshRoom.send(dummyArrayBuffer);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
+    });
+
+    describe('when the data type is object', () => {
+      const dummyObject = {'string': randomString(dummyDataSize)};
+
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const message = 'The size of data to send must be less than 20 MB';
+
+        try {
+          meshRoom.send(dummyObject);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
+      });
+
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
+
+        try {
+          meshRoom.send(dummyObject);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
     });
   });
 

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -365,8 +365,9 @@ describe('MeshRoom', () => {
       let str = '';
       const s =
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      for (let i = 0; i < size; i++) {
-        str += s[Math.floor(Math.random() * s.length)];
+      const iMax = Math.floor(size / 64);
+      for (let i = 0; i < iMax; i++) {
+        str += s;
       }
       return str;
     };

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -370,8 +370,10 @@ describe('MeshRoom', () => {
       }
       return str;
     };
-    const dummyDataSize = 21 * 1024 * 1024;
-    const dummyString = randomString(dummyDataSize);
+    const sizeOver = 21 * 1024 * 1024;
+    const sizeUnder = 19 * 1024 * 1024;
+    const stringSizeOver = randomString(sizeOver);
+    const stringSizeUnder = randomString(sizeUnder);
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -389,7 +391,7 @@ describe('MeshRoom', () => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          meshRoom.send(dummyString);
+          meshRoom.send(stringSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -402,24 +404,39 @@ describe('MeshRoom', () => {
         });
 
         try {
-          meshRoom.send(dummyString);
+          meshRoom.send(stringSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, meshRoomName);
+          assert.equal(message.data, stringSizeUnder);
+          done();
+        });
+
+        try {
+          meshRoom.send(stringSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
 
     describe('when the data type is binary (ArrayBuffer)', () => {
-      const dummyArrayBuffer = new ArrayBuffer(dummyDataSize);
+      const bufferSizeOver = new ArrayBuffer(sizeOver);
+      const bufferSizeUnder = new ArrayBuffer(sizeUnder);
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          meshRoom.send(dummyArrayBuffer);
+          meshRoom.send(bufferSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -432,24 +449,39 @@ describe('MeshRoom', () => {
         });
 
         try {
-          meshRoom.send(dummyArrayBuffer);
+          meshRoom.send(bufferSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, meshRoomName);
+          assert.equal(message.data, bufferSizeUnder);
+          done();
+        });
+
+        try {
+          meshRoom.send(bufferSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = { string: dummyString };
+      const objectSizeOver = { string: stringSizeOver };
+      const objectSizeUnder = { string: stringSizeUnder };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          meshRoom.send(dummyObject);
+          meshRoom.send(objectSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -462,13 +494,27 @@ describe('MeshRoom', () => {
         });
 
         try {
-          meshRoom.send(dummyObject);
+          meshRoom.send(objectSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, meshRoomName);
+          assert.equal(message.data, objectSizeUnder);
+          done();
+        });
+
+        try {
+          meshRoom.send(objectSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
   });

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -364,7 +364,7 @@ describe('MeshRoom', () => {
     const randomString = size => {
       let str = '';
       const s =
-            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
       for (let i = 0; i < size; i++) {
         str += s[Math.floor(Math.random() * s.length)];
       }
@@ -444,7 +444,7 @@ describe('MeshRoom', () => {
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = {'string': randomString(dummyDataSize)};
+      const dummyObject = { string: randomString(dummyDataSize) };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const message = 'The size of data to send must be less than 20 MB';

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -371,6 +371,7 @@ describe('MeshRoom', () => {
       return str;
     };
     const dummyDataSize = 21 * 1024 * 1024;
+    const dummyString = randomString(dummyDataSize);
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -384,8 +385,6 @@ describe('MeshRoom', () => {
     });
 
     describe('when the data type is string', () => {
-      const dummyString = randomString(dummyDataSize);
-
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const message = 'The size of data to send must be less than 20 MB';
 
@@ -444,7 +443,7 @@ describe('MeshRoom', () => {
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = { string: randomString(dummyDataSize) };
+      const dummyObject = { string: dummyString };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const message = 'The size of data to send must be less than 20 MB';

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -723,11 +723,9 @@ describe('Negotiator', () => {
             assert.fail('Should not emit iceCandidate event');
           });
 
-          [
-            {},
-            { candidate: null },
-            { candidate: { candidate: '' } },
-          ].forEach(ev => pc.onicecandidate(ev));
+          [{}, { candidate: null }, { candidate: { candidate: '' } }].forEach(
+            ev => pc.onicecandidate(ev)
+          );
         });
       });
 

--- a/tests/peer/negotiator.js
+++ b/tests/peer/negotiator.js
@@ -723,9 +723,11 @@ describe('Negotiator', () => {
             assert.fail('Should not emit iceCandidate event');
           });
 
-          [{}, { candidate: null }, { candidate: { candidate: '' } }].forEach(
-            ev => pc.onicecandidate(ev)
-          );
+          [
+            {},
+            { candidate: null },
+            { candidate: { candidate: '' } },
+          ].forEach(ev => pc.onicecandidate(ev));
         });
       });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -444,7 +444,7 @@ describe('SFURoom', () => {
     const randomString = size => {
       let str = '';
       const s =
-            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
       for (let i = 0; i < size; i++) {
         str += s[Math.floor(Math.random() * s.length)];
       }
@@ -558,7 +558,7 @@ describe('SFURoom', () => {
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = {'string': randomString(dummyDataSize)};
+      const dummyObject = { string: randomString(dummyDataSize) };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const sfuRoom = new SFURoom(sfuRoomName, peerId);

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -444,14 +444,13 @@ describe('SFURoom', () => {
     const randomString = size => {
       let str = '';
       const s =
-        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
       for (let i = 0; i < size; i++) {
         str += s[Math.floor(Math.random() * s.length)];
       }
       return str;
     };
-    const size = 21 * 10 ** 6;
-    const dummyLargeData = randomString(size);
+    const dummyDataSize = 21 * 1024 * 1024;
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -488,35 +487,109 @@ describe('SFURoom', () => {
       setTimeout(done);
     });
 
-    it('should throw an error when the size of data to send is greater than 20 MB', done => {
-      const sfuRoom = new SFURoom(sfuRoomName, peerId);
-      sfuRoom._open = true;
-      const message = 'The size of data to send must be less than 20 MB';
+    describe('when the data type is string', () => {
+      const dummyString = randomString(dummyDataSize);
 
-      try {
-        sfuRoom.send(dummyLargeData);
-      } catch (err) {
-        assert.strictEqual(err.message, message);
-        done();
-      }
-    });
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+        const message = 'The size of data to send must be less than 20 MB';
 
-    it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
-      const sfuRoom = new SFURoom(sfuRoomName, peerId);
-      sfuRoom._open = true;
-
-      sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
-        assert.fail('Should not have emitted a broadcast event');
+        try {
+          sfuRoom.send(dummyString);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
       });
 
-      try {
-        sfuRoom.send(dummyLargeData);
-      } catch (err) {
-        // empty
-      }
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
 
-      // let other async events run
-      setTimeout(done);
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
+
+        try {
+          sfuRoom.send(dummyString);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
+    });
+
+    describe('when the data type is binary (ArrayBuffer)', () => {
+      const dummyArrayBuffer = new ArrayBuffer(dummyDataSize);
+
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+        const message = 'The size of data to send must be less than 20 MB';
+
+        try {
+          sfuRoom.send(dummyArrayBuffer);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
+      });
+
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
+
+        try {
+          sfuRoom.send(dummyArrayBuffer);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
+    });
+
+    describe('when the data type is object', () => {
+      const dummyObject = {'string': randomString(dummyDataSize)};
+
+      it('should throw an error when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+        const message = 'The size of data to send must be less than 20 MB';
+
+        try {
+          sfuRoom.send(dummyObject);
+        } catch (err) {
+          assert.strictEqual(err.message, message);
+          done();
+        }
+      });
+
+      it('should not emit a broadcast event when the size of data to send is greater than 20 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          assert.fail('Should not have emitted a broadcast event');
+        });
+
+        try {
+          sfuRoom.send(dummyObject);
+        } catch (err) {
+          // empty
+        }
+
+        // let other async events run
+        setTimeout(done);
+      });
     });
   });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -442,14 +442,12 @@ describe('SFURoom', () => {
 
   describe('send', () => {
     const randomString = size => {
-      let str = '';
       const s =
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      const iMax = Math.floor(size / 64);
-      for (let i = 0; i < iMax; i++) {
-        str += s;
-      }
-      return str;
+      return (
+        s.repeat(Math.floor(size / s.length)) +
+        s.substring(s.length - (size % s.length))
+      );
     };
     const sizeOver = 21 * 1024 * 1024;
     const sizeUnder = 19 * 1024 * 1024;

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -445,8 +445,9 @@ describe('SFURoom', () => {
       let str = '';
       const s =
         'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      for (let i = 0; i < size; i++) {
-        str += s[Math.floor(Math.random() * s.length)];
+      const iMax = Math.floor(size / 64);
+      for (let i = 0; i < iMax; i++) {
+        str += s;
       }
       return str;
     };

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -451,6 +451,7 @@ describe('SFURoom', () => {
       return str;
     };
     const dummyDataSize = 21 * 1024 * 1024;
+    const dummyString = randomString(dummyDataSize);
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -488,8 +489,6 @@ describe('SFURoom', () => {
     });
 
     describe('when the data type is string', () => {
-      const dummyString = randomString(dummyDataSize);
-
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const sfuRoom = new SFURoom(sfuRoomName, peerId);
         sfuRoom._open = true;
@@ -558,7 +557,7 @@ describe('SFURoom', () => {
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = { string: randomString(dummyDataSize) };
+      const dummyObject = { string: dummyString };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const sfuRoom = new SFURoom(sfuRoomName, peerId);

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -450,8 +450,10 @@ describe('SFURoom', () => {
       }
       return str;
     };
-    const dummyDataSize = 21 * 1024 * 1024;
-    const dummyString = randomString(dummyDataSize);
+    const sizeOver = 21 * 1024 * 1024;
+    const sizeUnder = 19 * 1024 * 1024;
+    const stringSizeOver = randomString(sizeOver);
+    const stringSizeUnder = randomString(sizeUnder);
 
     it('should emit a broadcast event', done => {
       const data = 'foobar';
@@ -495,7 +497,7 @@ describe('SFURoom', () => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          sfuRoom.send(dummyString);
+          sfuRoom.send(stringSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -511,18 +513,36 @@ describe('SFURoom', () => {
         });
 
         try {
-          sfuRoom.send(dummyString);
+          sfuRoom.send(stringSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, sfuRoomName);
+          assert.equal(message.data, stringSizeUnder);
+          done();
+        });
+
+        try {
+          sfuRoom.send(stringSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
 
     describe('when the data type is binary (ArrayBuffer)', () => {
-      const dummyArrayBuffer = new ArrayBuffer(dummyDataSize);
+      const bufferSizeOver = new ArrayBuffer(sizeOver);
+      const bufferSizeUnder = new ArrayBuffer(sizeUnder);
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const sfuRoom = new SFURoom(sfuRoomName, peerId);
@@ -530,7 +550,7 @@ describe('SFURoom', () => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          sfuRoom.send(dummyArrayBuffer);
+          sfuRoom.send(bufferSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -546,18 +566,36 @@ describe('SFURoom', () => {
         });
 
         try {
-          sfuRoom.send(dummyArrayBuffer);
+          sfuRoom.send(bufferSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, sfuRoomName);
+          assert.equal(message.data, bufferSizeUnder);
+          done();
+        });
+
+        try {
+          sfuRoom.send(bufferSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
 
     describe('when the data type is object', () => {
-      const dummyObject = { string: dummyString };
+      const objectSizeOver = { string: stringSizeOver };
+      const objectSizeUnder = { string: stringSizeUnder };
 
       it('should throw an error when the size of data to send is greater than 20 MB', done => {
         const sfuRoom = new SFURoom(sfuRoomName, peerId);
@@ -565,7 +603,7 @@ describe('SFURoom', () => {
         const message = 'The size of data to send must be less than 20 MB';
 
         try {
-          sfuRoom.send(dummyObject);
+          sfuRoom.send(objectSizeOver);
         } catch (err) {
           assert.strictEqual(err.message, message);
           done();
@@ -581,13 +619,30 @@ describe('SFURoom', () => {
         });
 
         try {
-          sfuRoom.send(dummyObject);
+          sfuRoom.send(objectSizeOver);
         } catch (err) {
           // empty
         }
 
         // let other async events run
         setTimeout(done);
+      });
+
+      it('should emit a broadcast event when the size of data to send is 19 MB', done => {
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, message => {
+          assert.equal(message.roomName, sfuRoomName);
+          assert.equal(message.data, objectSizeUnder);
+          done();
+        });
+
+        try {
+          sfuRoom.send(objectSizeUnder);
+        } catch (err) {
+          // empty
+        }
       });
     });
   });


### PR DESCRIPTION
There is no limits of data size for sending data by using room.send method now.  To decrease the traffic load for skyway-servers, this PR limits the size of data that can be sent at one time by using SFU/MeshRoom.send() to 20 MB.