### PR TITLE
Add room.send interval limit

### DIFF
--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -250,13 +250,14 @@ class MeshRoom extends Room {
    * @param {*} data - The data to send.
    */
   send(data) {
+    if (!this.validateSendDataSize(data)) {
+      return;
+    }
     const message = {
       roomName: this.name,
       data: data,
     };
-    if (this.validateSendDataSize(data)) {
-      this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
-    }
+    this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
   }
 
   /**

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -257,7 +257,7 @@ class MeshRoom extends Room {
       roomName: this.name,
       data: data,
     };
-    this.emit(MeshRoom.MESSAGE_EVENTS.broadcast.key, message);
+    this._sendMessage(message, MeshRoom.MESSAGE_EVENTS.broadcast.key);
   }
 
   /**

--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -257,7 +257,7 @@ class MeshRoom extends Room {
       roomName: this.name,
       data: data,
     };
-    this._sendMessage(message, MeshRoom.MESSAGE_EVENTS.broadcast.key);
+    this._sendData(message, MeshRoom.MESSAGE_EVENTS.broadcast.key);
   }
 
   /**

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -96,7 +96,7 @@ class Room extends EventEmitter {
    * @param {object} msg - The data to send to this room.
    * @param {string} key - The key of broadcast event.
    */
-  _sendMessage(msg, key) {
+  _sendData(msg, key) {
     const sendInterval = config.minBroadcastIntervalMs;
 
     const now = Date.now();

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -61,6 +61,10 @@ class Room extends EventEmitter {
     this._localStream = this._options.stream;
 
     this._pcConfig = this._options.pcConfig;
+
+    this.lastSent = 0;
+    this.messageQueue = [];
+    this.sendIntervalID = null;
   }
 
   /**
@@ -85,6 +89,47 @@ class Room extends EventEmitter {
       throw new Error('The size of data to send must be less than 20 MB');
     }
     return true;
+  }
+
+  /**
+   * Send a message to the room with a delay so that the transmission interval does not exceed the limit.
+   * @param {object} msg - The data to send to this room.
+   * @param {string} key - The key of broadcast event.
+   */
+  _sendMessage(msg, key) {
+    const sendInterval = config.minBroadcastIntervalMs;
+
+    const now = Date.now();
+    const diff = now - this.lastsend;
+
+    // When no queued message and last message is enough old
+    if (this.messageQueue.length == 0 && diff >= sendInterval) {
+      // Update last send time send message without queueing.
+      this.lastsend = now;
+      this.emit(key, msg);
+      return;
+    }
+
+    // Send a message to the room with a delay because the transmission interval exceeds the limit.
+
+    // Push this message into a queue.
+    this.messageQueue.push({ msg, key });
+
+    // Return if setInterval is already set.
+    if (this.sendIntervalID !== null) {
+      return;
+    }
+    this.sendIntervalID = setInterval(() => {
+      // If all message are sent, remove this interval ID.
+      if (this.messageQueue.length === 0) {
+        clearInterval(this.sendIntervalID);
+        return;
+      }
+      // Update last send time send message.
+      const message = this.messageQueue.shift();
+      this.lastsend = Date.now();
+      this.emit(message.key, message.msg);
+    }, sendInterval);
   }
 
   /**

--- a/src/peer/room.js
+++ b/src/peer/room.js
@@ -104,7 +104,7 @@ class Room extends EventEmitter {
 
     // When no queued message and last message is enough old
     if (this.messageQueue.length == 0 && diff >= sendInterval) {
-      // Update last send time send message without queueing.
+      // Update last send time and send message without queueing.
       this.lastsend = now;
       this.emit(key, msg);
       return;

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -243,7 +243,7 @@ class SFURoom extends Room {
       roomName: this.name,
       data: data,
     };
-    this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
+    this._sendMessage(message, SFURoom.MESSAGE_EVENTS.broadcast.key);
   }
 
   /**

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -243,7 +243,7 @@ class SFURoom extends Room {
       roomName: this.name,
       data: data,
     };
-    this._sendMessage(message, SFURoom.MESSAGE_EVENTS.broadcast.key);
+    this._sendData(message, SFURoom.MESSAGE_EVENTS.broadcast.key);
   }
 
   /**

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -236,13 +236,14 @@ class SFURoom extends Room {
     if (!this._open) {
       return;
     }
+    if (!this.validateSendDataSize(data)) {
+      return;
+    }
     const message = {
       roomName: this.name,
       data: data,
     };
-    if (this.validateSendDataSize(data)) {
-      this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
-    }
+    this.emit(SFURoom.MESSAGE_EVENTS.broadcast.key, message);
   }
 
   /**

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -52,6 +52,9 @@ const maxChunkSize = 16300;
 // The maximum size of data that can be sent at one time by using Room.send() is 20 MB
 const maxDataSize = 20 * 1024 * 1024;
 
+// The minimum interval of using Room.send() is 100 ms
+const minBroadcastIntervalMs = 100;
+
 // Number of reconnection attempts to the same server before giving up
 const reconnectionAttempts = 2;
 
@@ -84,6 +87,7 @@ export default {
   MESSAGE_TYPES,
   maxChunkSize,
   maxDataSize,
+  minBroadcastIntervalMs,
   reconnectionAttempts,
   numberServersToTry,
   sendInterval,

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -517,7 +517,7 @@ describe('MeshRoom', () => {
       });
     });
 
-    it('should emit a brodcast evnet at intervals greater than limit even if send intervals are smaller than limit', async () => {
+    it('should emit a broadcast event at intervals greater than limit even if send intervals are smaller than limit', async () => {
       const data = 'foobar';
 
       const sendIntervalMs = 10;

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -516,6 +516,79 @@ describe('MeshRoom', () => {
         }
       });
     });
+
+    it('should emit a brodcast evnet at intervals greater than limit even if send intervals are smaller than limit', async () => {
+      const data = 'foobar';
+
+      const sendIntervalMs = 10;
+      const broadcastInterval = 100;
+      const toleranceRange = 5;
+
+      let lastEventTime = 0;
+      meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+        const now = Date.now();
+        const diff = now - lastEventTime;
+        if (diff < broadcastInterval - toleranceRange) {
+          assert.fail(`broadcast event is emitted too early: ${diff} ms`);
+        }
+        lastEventTime = now;
+      });
+
+      const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+      for (let i = 0; i < 10; ++i) {
+        meshRoom.send(data);
+        await sleep(sendIntervalMs);
+      }
+    });
+
+    it('should queue if message queue is not empty', async () => {
+      const data = 'foobar';
+
+      const sendIntervalMs = 110;
+      const broadcastInterval = 100;
+      const toleranceRange = 5;
+
+      let lastEventTime = 0;
+      meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+        const now = Date.now();
+        const diff = now - lastEventTime;
+        if (diff < broadcastInterval - toleranceRange) {
+          assert.fail(`broadcast event is emitted too early: ${diff} ms`);
+        }
+        lastEventTime = now;
+      });
+
+      const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+      for (let i = 0; i < 5; ++i) {
+        meshRoom.send(data);
+      }
+      for (let i = 0; i < 5; ++i) {
+        meshRoom.send(data);
+        await sleep(sendIntervalMs);
+      }
+    });
+
+    it('should emit a broadcaset event without delay if send intervals are greter than limit', async () => {
+      const data = 'foobar';
+
+      const sendIntervalMs = 150;
+      const broadcastMaxDelayMs = sendIntervalMs * 10 + 100;
+
+      const lastEventTime = Date.now();
+      meshRoom.on(MeshRoom.MESSAGE_EVENTS.broadcast.key, () => {
+        const now = Date.now();
+        const diff = now - lastEventTime;
+        if (diff > broadcastMaxDelayMs) {
+          assert.fail(`broadcast event is emitted too later: ${diff} ms`);
+        }
+      });
+
+      const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+      for (let i = 0; i < 10; ++i) {
+        meshRoom.send(data);
+        await sleep(sendIntervalMs);
+      }
+    });
   });
 
   describe('close', () => {

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -537,6 +537,88 @@ describe('SFURoom', () => {
           // empty
         }
       });
+
+      it('should emit a brodcast evnet at intervals greater than limit even if send intervals are smaller than limit', async () => {
+        const data = 'foobar';
+
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        const sendIntervalMs = 10;
+        const broadcastInterval = 100;
+        const toleranceRange = 5;
+
+        let lastEventTime = 0;
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          const now = Date.now();
+          const diff = now - lastEventTime;
+          if (diff < broadcastInterval - toleranceRange) {
+            assert.fail(`broadcast event is emitted too early: ${diff} ms`);
+          }
+          lastEventTime = now;
+        });
+
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+        for (let i = 0; i < 10; ++i) {
+          sfuRoom.send(data);
+          await sleep(sendIntervalMs);
+        }
+      });
+
+      it('should queue if message queue is not empty', async () => {
+        const data = 'foobar';
+
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        const sendIntervalMs = 110;
+        const broadcastInterval = 100;
+        const toleranceRange = 5;
+
+        let lastEventTime = 0;
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          const now = Date.now();
+          const diff = now - lastEventTime;
+          if (diff < broadcastInterval - toleranceRange) {
+            assert.fail(`broadcast event is emitted too early: ${diff} ms`);
+          }
+          lastEventTime = now;
+        });
+
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+        for (let i = 0; i < 5; ++i) {
+          sfuRoom.send(data);
+        }
+        for (let i = 0; i < 5; ++i) {
+          sfuRoom.send(data);
+          await sleep(sendIntervalMs);
+        }
+      });
+
+      it('should emit a broadcaset event without delay if send intervals are greter than limit', async () => {
+        const data = 'foobar';
+
+        const sfuRoom = new SFURoom(sfuRoomName, peerId);
+        sfuRoom._open = true;
+
+        const sendIntervalMs = 150;
+        const broadcastMaxDelayMs = sendIntervalMs * 10 + 100;
+
+        const lastEventTime = Date.now();
+        sfuRoom.on(SFURoom.MESSAGE_EVENTS.broadcast.key, () => {
+          const now = Date.now();
+          const diff = now - lastEventTime;
+          if (diff > broadcastMaxDelayMs) {
+            assert.fail(`broadcast event is emitted too later: ${diff} ms`);
+          }
+        });
+
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+        for (let i = 0; i < 10; ++i) {
+          sfuRoom.send(data);
+          await sleep(sendIntervalMs);
+        }
+      });
     });
 
     describe('when the data type is binary (ArrayBuffer)', () => {

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -538,7 +538,7 @@ describe('SFURoom', () => {
         }
       });
 
-      it('should emit a brodcast evnet at intervals greater than limit even if send intervals are smaller than limit', async () => {
+      it('should emit a broadcast event at intervals greater than limit even if send intervals are smaller than limit', async () => {
         const data = 'foobar';
 
         const sfuRoom = new SFURoom(sfuRoomName, peerId);


### PR DESCRIPTION
There are no limits of sending interval for sending data by using room.send method now. To decrease the traffic load for skyway-servers, this PR limits the sending interval that room.send sends messages to 100ms.