### PR TITLE
Change default value of connection.close() from false to true

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -177,7 +177,7 @@ class Connection extends EventEmitter {
    * Disconnect from remote peer.
    * @fires Connection#close
    */
-  close(forceClose = false) {
+  close(forceClose = true) {
     if (!this.open) {
       return;
     }

--- a/tests/peer/mediaConnection.js
+++ b/tests/peer/mediaConnection.js
@@ -419,7 +419,7 @@ describe('MediaConnection', () => {
       assert(spy.withArgs(Connection.EVENTS.forceClose.key).notCalled);
     });
 
-    it('should not emit a forceClose event when call close() by default', () => {
+    it('should emit a forceClose event when call close() by default', () => {
       const mc = new MediaConnection('remoteId', { stream: {} });
       const spy = sinon.spy(mc, 'emit');
       // Force to be open
@@ -427,7 +427,7 @@ describe('MediaConnection', () => {
 
       mc.close();
 
-      assert(spy.withArgs(Connection.EVENTS.forceClose.key).notCalled);
+      assert(spy.withArgs(Connection.EVENTS.forceClose.key).calledOnce);
     });
   });
 });


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other (please describe):

### Summary

Change default value of `connection.close()` from false to true.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
