### PR TITLE
Add deprecated tag and description for connection.close().

### DIFF
--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -176,6 +176,7 @@ class Connection extends EventEmitter {
   /**
    * Disconnect from remote peer.
    * @fires Connection#close
+   * @deprecated Default value of forceClose may be changed to true from a future version.
    */
   close(forceClose = true) {
     if (!this.open) {
@@ -186,6 +187,10 @@ class Connection extends EventEmitter {
     this._negotiator.cleanup();
     this.emit(Connection.EVENTS.close.key);
 
+    logger.warn(
+      `Parameter forceClose = false is deprecated and may be changed to forceClose = true from a future version.` +
+        ` Please use ${this.constructor.name}.close(true).`
+    );
     if (forceClose) {
       this.emit(Connection.EVENTS.forceClose.key);
     }

--- a/src/peer/connection.js
+++ b/src/peer/connection.js
@@ -187,12 +187,13 @@ class Connection extends EventEmitter {
     this._negotiator.cleanup();
     this.emit(Connection.EVENTS.close.key);
 
-    logger.warn(
-      `Parameter forceClose = false is deprecated and may be changed to forceClose = true from a future version.` +
-        ` Please use ${this.constructor.name}.close(true).`
-    );
     if (forceClose) {
       this.emit(Connection.EVENTS.forceClose.key);
+    } else {
+      logger.warn(
+        `Parameter forceClose = false is deprecated and may be changed to forceClose = true from a future version.` +
+          ` Please use ${this.constructor.name}.close(true).`
+      );
     }
   }
 

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -277,8 +277,13 @@ class DataConnection extends Connection {
   /**
    * Disconnect from remote peer.
    * @fires DataConnection#close
+   * @deprecated Default value of forceClose may be changed to true from a future version.
    */
   close(forceClose) {
+    logger.warn(
+      `Parameter forceClose = false is deprecated and may be changed to forceClose = true from a future version.` +
+        ` Please use ${this.constructor.name}.close(true).`
+    );
     super.close(forceClose);
 
     this._isOnOpenCalled = false;

--- a/src/peer/dataConnection.js
+++ b/src/peer/dataConnection.js
@@ -280,10 +280,6 @@ class DataConnection extends Connection {
    * @deprecated Default value of forceClose may be changed to true from a future version.
    */
   close(forceClose) {
-    logger.warn(
-      `Parameter forceClose = false is deprecated and may be changed to forceClose = true from a future version.` +
-        ` Please use ${this.constructor.name}.close(true).`
-    );
     super.close(forceClose);
 
     this._isOnOpenCalled = false;


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other (please describe):

### Summary

Added deprecated tag and description for connection.close() since the default value of forceClose may be deprecated.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
