### PR TITLE
Add getPeerConnections() to mesh and sfu room

### DIFF
--- a/src/peer/meshRoom.js
+++ b/src/peer/meshRoom.js
@@ -296,6 +296,20 @@ class MeshRoom extends Room {
   }
 
   /**
+   * Get all of each peer's RTCPeerConnection.
+   */
+  getPeerConnections() {
+    const peerConnections = {};
+    for (const [peerId, [connection]] of Object.entries(this.connections)) {
+      const pc = connection.getPeerConnection();
+      if (pc) {
+        peerConnections[peerId] = pc;
+      }
+    }
+    return peerConnections;
+  }
+
+  /**
    * Append a connection to peer's array of connections, stored in room.connections.
    * @param {string} peerId - User's peerID.
    * @param {MediaConnection|DataConnection} connection - An instance of MediaConnection or DataConnection.

--- a/src/peer/sfuRoom.js
+++ b/src/peer/sfuRoom.js
@@ -301,6 +301,16 @@ class SFURoom extends Room {
   }
 
   /**
+   * Get a RTCPeerConnection.
+   */
+  getPeerConnection() {
+    if (!this._connectionStarted) {
+      return null;
+    }
+    return this._negotiator._pc;
+  }
+
+  /**
    * Events the SFURoom class can emit.
    * @type {Enum}
    */

--- a/tests/peer/meshRoom.js
+++ b/tests/peer/meshRoom.js
@@ -21,6 +21,7 @@ describe('MeshRoom', () => {
   let closeSpy;
   let answerSpy;
   let replaceStreamSpy;
+  let getPeerConnectionStub;
 
   beforeEach(() => {
     mcStub = sinon.stub();
@@ -29,6 +30,7 @@ describe('MeshRoom', () => {
     closeSpy = sinon.spy();
     answerSpy = sinon.spy();
     replaceStreamSpy = sinon.spy();
+    getPeerConnectionStub = sinon.stub();
 
     mcStub.returns({
       type: 'media',
@@ -37,6 +39,7 @@ describe('MeshRoom', () => {
       close: closeSpy,
       answer: answerSpy,
       replaceStream: replaceStreamSpy,
+      getPeerConnection: getPeerConnectionStub,
     });
     // hoist statics
     mcStub.EVENTS = MediaConnection.EVENTS;
@@ -64,6 +67,7 @@ describe('MeshRoom', () => {
     closeSpy.resetHistory();
     answerSpy.resetHistory();
     replaceStreamSpy.resetHistory();
+    getPeerConnectionStub.resetHistory();
   });
 
   describe('Constructor', () => {
@@ -639,6 +643,30 @@ describe('MeshRoom', () => {
       meshRoom.replaceStream(newStream);
 
       assert.equal(replaceStreamSpy.callCount, 0);
+    });
+  });
+
+  describe('getPeerConnections', () => {
+    it('should return all of each RTCPeerConnection', () => {
+      const peers = ['peerId1', 'peerId2'];
+      meshRoom.makeMediaConnections(peers);
+      getPeerConnectionStub.onCall(0).returns('peerId1_pc');
+      getPeerConnectionStub.onCall(1).returns('peerId2_pc');
+
+      const pcs = meshRoom.getPeerConnections();
+
+      assert.deepStrictEqual(pcs, {
+        peerId1: 'peerId1_pc',
+        peerId2: 'peerId2_pc',
+      });
+    });
+
+    it('should return an empty object if meshRoom.connections are empty', () => {
+      meshRoom.connections = {};
+
+      const pcs = meshRoom.getPeerConnections();
+
+      assert.deepStrictEqual(pcs, {});
     });
   });
 

--- a/tests/peer/sfuRoom.js
+++ b/tests/peer/sfuRoom.js
@@ -796,6 +796,25 @@ describe('SFURoom', () => {
     });
   });
 
+  describe('getPeerConnection', () => {
+    it('should return null if _connectionStarted is not true', () => {
+      sfuRoom._connectionStarted = false;
+
+      const pc = sfuRoom.getPeerConnection();
+
+      assert.equal(pc, null);
+    });
+
+    it('should return RTCPeerConnection object if _connectionStarted is true', () => {
+      sfuRoom._negotiator._pc = {};
+      sfuRoom._connectionStarted = true;
+
+      const pc = sfuRoom.getPeerConnection();
+
+      assert.deepEqual(pc, {});
+    });
+  });
+
   /** Inherited from Room */
   describe('handleData', () => {
     it('should emit a data event', done => {


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary

Added `getPeerConnections` method to Mesh and SFURoom classes.
This enables users to get `RTCPeerConnection`, so they will be able to use useful APIs like `RTCPeerConnection.getStats()` in mesh and sfu room as well.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
