### PR TITLE
Add export statement to some declared classes

### DIFF
--- a/skyway-js.d.ts
+++ b/skyway-js.d.ts
@@ -74,7 +74,7 @@ export interface AnswerOption {
   audioReceiveEnabled?: boolean;
 }
 
-declare class Connection extends EventEmitter {
+export declare class Connection extends EventEmitter {
   open: boolean;
   type: string;
   metadata: any;
@@ -144,7 +144,7 @@ export interface RoomStream extends MediaStream {
   peerId: string;
 }
 
-declare class Room extends EventEmitter {
+export declare class Room extends EventEmitter {
   name: string;
 
   getLog(): void;
@@ -186,7 +186,7 @@ export declare class SfuRoom extends Room {
   members: string[];
 }
 
-declare class Peer extends EventEmitter {
+export declare class Peer extends EventEmitter {
   id: string;
   connections: {
     [peerId: string]: MediaConnection[] | DataConnection[];


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary
Add export statement to declared classes.
This change helps users to declare and use variables.

ex)
```ts
// Before
class Hoge {
  private peer;

  public connect() {
    this.peer = new Peer(...);
    // ...
  }

  public disconnect() {
    this.peer.disconnect() // Unable to infer the type
  }
}

// After
class Hoge {
  private peer: Peer | null = null;

  public connect() {
    this.peer = new Peer(...);
    // ...
  }

  public disconnect() {
    this.peer.disconnect() // OK
  }
}
```

### Related Links (Issue, PR etc...) (_Optional_)
#275 

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
