### PR TITLE
Make sure to try to reconnect when request to dispatcher fails

### DIFF
--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -136,7 +136,8 @@ class Socket extends EventEmitter {
     try {
       serverInfo = await this._getSignalingServer();
     } catch (err) {
-      this._io.emit('error', err);
+      this._connectToNewServer(++numAttempts);
+      return;
     }
 
     if (this.signalingServerUrl.indexOf(serverInfo.host) === -1) {

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -136,8 +136,7 @@ class Socket extends EventEmitter {
     try {
       serverInfo = await this._getSignalingServer();
     } catch (err) {
-      this.emit('error', err);
-      return;
+      this._io.emit('error', err);
     }
 
     if (this.signalingServerUrl.indexOf(serverInfo.host) === -1) {


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary

There is a bug that a reconnect process to the signaling-server is stopped because the Peer's error event was fired when request to the dispatcher failed.

This PR allows to try to reconnect in such case.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
