### PR TITLE
Make sure to try to reconnect when request to dispatcher fails

### DIFF
--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -136,7 +136,7 @@ class Socket extends EventEmitter {
     try {
       serverInfo = await this._getSignalingServer();
     } catch (err) {
-      this.emit('error', err);
+      this._connectToNewServer(++numAttempts);
       return;
     }
 

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -136,7 +136,8 @@ class Socket extends EventEmitter {
     try {
       serverInfo = await this._getSignalingServer();
     } catch (err) {
-      this._connectToNewServer(++numAttempts);
+      // Call with await to ensure that this method attempts up to the limit before giving up in a test case.
+      await this._connectToNewServer(++numAttempts);
       return;
     }
 

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -135,7 +135,7 @@ class Socket extends EventEmitter {
 
   /**
    * Return signaling server url. This attempts trying up to maxNumberOfAttempts times before giving up then throw error.
-   * @return {String} A string of signaling server uri.
+   * @return {String} A string of signaling server url.
    */
   async _getSignalingServerUrlWithRetry() {
     for (let attempts = 0; attempts < config.maxNumberOfAttempts; attempts++) {
@@ -153,7 +153,7 @@ class Socket extends EventEmitter {
         return `${httpProtocol}${serverInfo.host}:${serverInfo.port}`;
       }
     }
-    throw new Error('Could not get signaling server uri.');
+    throw new Error('Could not get signaling server url.');
   }
 
   /**

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -86,7 +86,7 @@ class Socket extends EventEmitter {
 
     if (this._dispatcherUrl) {
       try {
-        this.signalingServerUrl = await this._getSignalingServerUrlWithRetry();
+        this.signalingServerUrl = await this._fetchSignalingServerUrlWithRetry();
       } catch (err) {
         this.emit('error', err);
         return;
@@ -123,7 +123,7 @@ class Socket extends EventEmitter {
     }
 
     try {
-      this.signalingServerUrl = await this._getSignalingServerUrlWithRetry();
+      this.signalingServerUrl = await this._fetchSignalingServerUrlWithRetry();
     } catch (err) {
       this.emit('error', err);
       return;
@@ -137,9 +137,9 @@ class Socket extends EventEmitter {
    * Return signaling server url. This attempts trying up to maxNumberOfAttempts times before giving up then throw error.
    * @return {String} A string of signaling server url.
    */
-  async _getSignalingServerUrlWithRetry() {
+  async _fetchSignalingServerUrlWithRetry() {
     for (let attempts = 0; attempts < config.maxNumberOfAttempts; attempts++) {
-      const serverInfo = await this._getSignalingServer().catch(err => {
+      const serverInfo = await this._fetchSignalingServer().catch(err => {
         logger.warn(err);
       });
       if (
@@ -161,7 +161,7 @@ class Socket extends EventEmitter {
    * @return {Promise<Object>} A promise that resolves with signaling server info
    and rejects if there's no response or status code isn't 200.
    */
-  _getSignalingServer() {
+  _fetchSignalingServer() {
     return new Promise((resolve, reject) => {
       const http = new XMLHttpRequest();
 

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -55,6 +55,9 @@ const maxDataSize = 20 * 1024 * 1024;
 // The minimum interval of using Room.send() is 100 ms
 const minBroadcastIntervalMs = 100;
 
+// max number of attempts to get a new server from the dispatcher.
+const maxNumberOfAttempts = 10;
+
 // Number of reconnection attempts to the same server before giving up
 const reconnectionAttempts = 2;
 
@@ -88,6 +91,7 @@ export default {
   maxChunkSize,
   maxDataSize,
   minBroadcastIntervalMs,
+  maxNumberOfAttempts,
   reconnectionAttempts,
   numberServersToTry,
   sendInterval,

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -62,7 +62,7 @@ const maxNumberOfAttempts = 10;
 const reconnectionAttempts = 2;
 
 // Number of times to try changing servers before giving up
-const numberServersToTry = 3;
+const numberServersToTry = 10;
 
 // Send loop interval in milliseconds
 const sendInterval = 1;

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -62,7 +62,7 @@ const maxNumberOfAttempts = 10;
 const reconnectionAttempts = 2;
 
 // Number of times to try changing servers before giving up
-const numberServersToTry = 10;
+const numberServersToTry = 3;
 
 // Send loop interval in milliseconds
 const sendInterval = 1;

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -589,4 +589,31 @@ describe('Socket', () => {
       });
     });
   });
+
+  describe('_connectToNewServer', () => {
+    const errorMessage = 'Could not connect to server.';
+    let connectToNewServerSpy;
+    let emitStub;
+    let getSignalingServerStub;
+
+    beforeEach(() => {
+      connectToNewServerSpy = sinon.spy(socket, '_connectToNewServer');
+      emitStub = sinon.stub(socket, 'emit');
+      getSignalingServerStub = sinon.stub(socket, '_getSignalingServer');
+      getSignalingServerStub.returns(Promise.reject(new Error('error')));
+    });
+
+    afterEach(() => {
+      connectToNewServerSpy.restore();
+      emitStub.restore();
+      getSignalingServerStub.restore();
+    });
+
+    it('should attempt up to 11 times before giving up and emitting an error on the socket', async () => {
+      await socket._connectToNewServer();
+
+      assert.equal(connectToNewServerSpy.callCount, 11);
+      assert.deepEqual(emitStub.args[0], ['error', errorMessage]);
+    });
+  });
 });

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -105,7 +105,7 @@ describe('Socket', () => {
       const signalingHost = 'signaling.io';
       const signalingPort = 443;
       const signalingSecure = true;
-      let getSignalingServerStub;
+      let fetchSignalingServerStub;
 
       beforeEach(() => {
         socket = new Socket(apiKey, {
@@ -114,8 +114,8 @@ describe('Socket', () => {
           dispatcherSecure: dispatcherSecure,
         });
 
-        getSignalingServerStub = sinon.stub(socket, '_getSignalingServer');
-        getSignalingServerStub.returns(
+        fetchSignalingServerStub = sinon.stub(socket, '_fetchSignalingServer');
+        fetchSignalingServerStub.returns(
           Promise.resolve({
             host: signalingHost,
             port: signalingPort,
@@ -125,7 +125,7 @@ describe('Socket', () => {
       });
 
       afterEach(() => {
-        getSignalingServerStub.restore();
+        fetchSignalingServerStub.restore();
       });
 
       it('should set _dispatcherUrl', () => {
@@ -135,7 +135,7 @@ describe('Socket', () => {
         );
       });
 
-      it('should get set the signalingServerUrl from _getSignalingServer', done => {
+      it('should get set the signalingServerUrl from _fetchSignalingServer', done => {
         socket.start(null, token).then(() => {
           const httpProtocol = signalingSecure ? 'https://' : 'http://';
           const signalingServerUrl = `${httpProtocol}${signalingHost}:${signalingPort}`;
@@ -419,7 +419,7 @@ describe('Socket', () => {
     });
   });
 
-  describe('_getSignalingServer', () => {
+  describe('_fetchSignalingServer', () => {
     let requests = [];
     let xhr;
     const fakeDomain = 'fake.domain';
@@ -443,7 +443,7 @@ describe('Socket', () => {
       const result = { domain: fakeDomain };
 
       socket
-        ._getSignalingServer()
+        ._fetchSignalingServer()
         .then(() => {
           assert.equal(requests.length, 1);
 
@@ -469,7 +469,7 @@ describe('Socket', () => {
         const result = { domain: fakeDomain };
 
         socket
-          ._getSignalingServer()
+          ._fetchSignalingServer()
           .then(res => {
             assert.deepEqual(res, {
               host: fakeDomain,
@@ -492,7 +492,7 @@ describe('Socket', () => {
         const result = {};
 
         socket
-          ._getSignalingServer()
+          ._fetchSignalingServer()
           .then(() => {
             assert.fail('This should be rejected.');
             done();
@@ -516,7 +516,7 @@ describe('Socket', () => {
         };
 
         socket
-          ._getSignalingServer()
+          ._fetchSignalingServer()
           .then(() => {
             assert.fail('This should be rejected.');
             done();
@@ -543,7 +543,7 @@ describe('Socket', () => {
           },
         };
         socket
-          ._getSignalingServer()
+          ._fetchSignalingServer()
           .then(() => {
             assert.fail('This should be rejected.');
             done();
@@ -571,7 +571,7 @@ describe('Socket', () => {
         };
 
         socket
-          ._getSignalingServer()
+          ._fetchSignalingServer()
           .then(() => {
             assert.fail('This should be rejected.');
             done();
@@ -590,19 +590,19 @@ describe('Socket', () => {
     });
   });
 
-  describe('_getSignalingServerUrlWithRetry', () => {
+  describe('_fetchSignalingServerUrlWithRetry', () => {
     const signalingHost = 'signaling.io';
     const signalingPort = 443;
     const signalingSecure = true;
     const httpProtocol = 'https://';
     const signalingServerUrl = `${httpProtocol}${signalingHost}:${signalingPort}`;
     let emitStub;
-    let getSignalingServerStub;
+    let fetchSignalingServerStub;
 
     beforeEach(() => {
       emitStub = sinon.stub(socket, 'emit');
-      getSignalingServerStub = sinon.stub(socket, '_getSignalingServer');
-      getSignalingServerStub.returns(
+      fetchSignalingServerStub = sinon.stub(socket, '_fetchSignalingServer');
+      fetchSignalingServerStub.returns(
         Promise.resolve({
           host: signalingHost,
           port: signalingPort,
@@ -613,11 +613,11 @@ describe('Socket', () => {
 
     afterEach(() => {
       emitStub.restore();
-      getSignalingServerStub.restore();
+      fetchSignalingServerStub.restore();
     });
 
     it('should return signalingServerUrl', async () => {
-      const url = await socket._getSignalingServerUrlWithRetry();
+      const url = await socket._fetchSignalingServerUrlWithRetry();
 
       assert.equal(url, signalingServerUrl);
     });
@@ -625,38 +625,38 @@ describe('Socket', () => {
     it('should attempt 10 times before giving up and throw error', async () => {
       socket.signalingServerUrl = signalingServerUrl;
 
-      await socket._getSignalingServerUrlWithRetry().catch(err => {
-        assert.equal(getSignalingServerStub.callCount, 10);
+      await socket._fetchSignalingServerUrlWithRetry().catch(err => {
+        assert.equal(fetchSignalingServerStub.callCount, 10);
         assert.equal(err.message, 'Could not get signaling server url.');
       });
 
-      // assert.throws(await socket._getSignalingServerUrlWithRetry(), 'Could not get signaling server url.');
+      // assert.throws(await socket._fetchSignalingServerUrlWithRetry(), 'Could not get signaling server url.');
     });
   });
 
   describe('_connectToNewServer', () => {
     let connectToNewServerSpy;
     let emitStub;
-    let getSignalingServerUrlWithRetryStub;
+    let fetchSignalingServerUrlWithRetryStub;
 
     beforeEach(() => {
       connectToNewServerSpy = sinon.spy(socket, '_connectToNewServer');
       emitStub = sinon.stub(socket, 'emit');
-      getSignalingServerUrlWithRetryStub = sinon.stub(
+      fetchSignalingServerUrlWithRetryStub = sinon.stub(
         socket,
-        '_getSignalingServerUrlWithRetry'
+        '_fetchSignalingServerUrlWithRetry'
       );
     });
 
     afterEach(() => {
       connectToNewServerSpy.restore();
       emitStub.restore();
-      getSignalingServerUrlWithRetryStub.restore();
+      fetchSignalingServerUrlWithRetryStub.restore();
     });
 
     it('should set _io.io.uri', () => {
       const signalingServerUrl = 'https:signaling.io:443';
-      getSignalingServerUrlWithRetryStub.returns(signalingServerUrl);
+      fetchSignalingServerUrlWithRetryStub.returns(signalingServerUrl);
 
       socket.start(undefined, token).then(async () => {
         await socket._connectToNewServer();
@@ -667,7 +667,7 @@ describe('Socket', () => {
 
     describe('when response from dispatcher is empty', () => {
       it('should emit an error on the socket', async () => {
-        getSignalingServerUrlWithRetryStub.throws();
+        fetchSignalingServerUrlWithRetryStub.throws();
 
         await socket._connectToNewServer();
 

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -627,7 +627,7 @@ describe('Socket', () => {
 
       await socket._getSignalingServerUrlWithRetry().catch(err => {
         assert.equal(getSignalingServerStub.callCount, 10);
-        assert.deepEqual(err, new Error('Could not get signaling server url.'));
+        assert.equal(err.message, 'Could not get signaling server url.');
       });
 
       // assert.throws(await socket._getSignalingServerUrlWithRetry(), 'Could not get signaling server url.');

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -655,7 +655,7 @@ describe('Socket', () => {
     });
 
     it('should set _io.io.uri', () => {
-      const signalingServerUrl = 'https:signaling.io:443';
+      const signalingServerUrl = 'https://signaling.io:443';
       fetchSignalingServerUrlWithRetryStub.returns(signalingServerUrl);
 
       socket.start(undefined, token).then(async () => {

--- a/tests/peer/socket.js
+++ b/tests/peer/socket.js
@@ -598,7 +598,10 @@ describe('Socket', () => {
     beforeEach(() => {
       connectToNewServerSpy = sinon.spy(socket, '_connectToNewServer');
       emitStub = sinon.stub(socket, 'emit');
-      getSignalingServerUrlWithRetryStub = sinon.stub(socket, '_getSignalingServerUrlWithRetry');
+      getSignalingServerUrlWithRetryStub = sinon.stub(
+        socket,
+        '_getSignalingServerUrlWithRetry'
+      );
     });
 
     afterEach(() => {
@@ -624,10 +627,7 @@ describe('Socket', () => {
 
         await socket._connectToNewServer();
 
-        assert.deepEqual(emitStub.args[0], [
-          'error',
-          new Error(),
-        ]);
+        assert.deepEqual(emitStub.args[0], ['error', new Error()]);
       });
     });
   });


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary

There is a bug that a reconnect process to the signaling-server is stopped because the Peer's error event was fired when request to the dispatcher failed.

This PR allows to try to reconnect in such case.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish