### PR TITLE
Update changelog and sdk version for v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## release note
 
+## [v4.4.0](https://github.com/skyway/skyway-js-sdk/releases/tag/v4.4.0) - 2021-02-15
+
+### Deprecated
+
+- Deprecated `Peer.reconnect()`, `Peer.disconnect()` and `disconnected` event on `Peer`. ([#308](https://github.com/skyway/skyway-js-sdk/pull/308))
+
 ## [v4.3.0](https://github.com/skyway/skyway-js-sdk/releases/tag/v4.3.0) - 2021-01-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skyway-js",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "The official JavaScript SDK for SkyWay",
   "main": "dist/skyway.js",
   "types": "skyway-js.d.ts",


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Documentation content changes

### Summary

Update changelog and sdk version for v4.4.0.

- Deprecated 
  - `Peer.reconnect()`
  - `Peer.disconnect()`
  - `disconnected` event on `Peer`

### Related Links (Issue, PR etc...) (_Optional_)

https://github.com/skyway/skyway-js-sdk/pull/308

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
