### PR TITLE
Revert "Update to use XHR if Safari 15 or over"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Updated to use only XHR if Safari 15 or over, due to a bug in Safari 15. ([#318](https://github.com/skyway/skyway-js-sdk/pull/318))
+- Updated to use only XHR if Safari 15, due to a bug in Safari 15. ([#318](https://github.com/skyway/skyway-js-sdk/pull/318))
 
 ## [v4.4.1](https://github.com/skyway/skyway-js-sdk/releases/tag/v4.4.1) - 2021-03-29
 

--- a/src/peer/socket.js
+++ b/src/peer/socket.js
@@ -97,11 +97,8 @@ class Socket extends EventEmitter {
     // Due to a bug in Safari 15,
     // WebSocket cannot send data properly, so we only use XHR temporarily.
     const brower = util.detectBrowser();
-    const isSafari15OrOver =
-      (brower.name === 'ios' || brower.name === 'safari') && brower.major >= 15;
-    const transports = isSafari15OrOver
-      ? ['polling']
-      : ['polling', 'websocket'];
+    const isSafari = brower.name === 'ios' || brower.name === 'safari';
+    const transports = isSafari ? ['polling'] : ['polling', 'websocket'];
 
     this._io = io(this.signalingServerUrl, {
       'force new connection': true,


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Bugfix

### Summary
Revert #320 

### Related Links (Issue, PR etc...) (_Optional_)
https://github.com/skyway/skyway-js-sdk/pull/320

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
