### PR TITLE
Add null check before RTCPeerConnection.addIceCandidate

### DIFF
--- a/src/peer/negotiator.js
+++ b/src/peer/negotiator.js
@@ -233,6 +233,10 @@ class Negotiator extends EventEmitter {
    * @return {Promise<void>} Promise that resolves when handling candidate is done.
    */
   async handleCandidate(candidate) {
+    if (!this._pc) {
+      return;
+    }
+
     await this._pc
       .addIceCandidate(new RTCIceCandidate(candidate))
       .then(() => logger.log('Successfully added ICE candidate'))


### PR DESCRIPTION
### Please check the type of change your PR introduces

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

### Summary

`Negotiator._pc (RTCPeerConnection instance)` will be `null` when `Negotiator.cleanup` is called.
So we need to add null check before `RTCPeerConnection.addIceCandidate` in `Negotiator.handleCandidate`.

### Related Links (Issue, PR etc...) (_Optional_)

### Check point

- [x] Check merge target branch
- [x] ( For SkyWay team ) This is public repository **Please Check AGAIN** before publish
